### PR TITLE
DI Container no longer uses WP function

### DIFF
--- a/plugins/versionpress/src/DI/DIContainer.php
+++ b/plugins/versionpress/src/DI/DIContainer.php
@@ -57,11 +57,12 @@ class DIContainer {
         });
 
         $dic->register(VersionPressServices::STORAGE_FACTORY, function () use ($dic) {
+            global $wp_taxonomies;
             return new StorageFactory(
                 VERSIONPRESS_MIRRORING_DIR,
                 $dic->resolve(VersionPressServices::DB_SCHEMA),
                 $dic->resolve(VersionPressServices::WPDB),
-                get_taxonomies()
+                array_keys((array)$wp_taxonomies)
             );
         });
 


### PR DESCRIPTION
Resolves #541 

We use DI container also from tests, where the `get_taxonomies` function does not exist. So we used a global variable containing taxonomies instead of the function – it's ugly, but we will solve filtering entities in 3.0 and this will disappear.
