### PR TITLE
Error creating config on Windows in `vp restore-site`

### DIFF
--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -275,7 +275,7 @@ class VPCommand extends WP_CLI_Command {
         $configArgs['dbhost'] = @$assoc_args['dbhost'] ?: '127.0.0.1';
         $configArgs['dbprefix'] = @$assoc_args['dbprefix'] ?: 'wp_';
         $configArgs['dbcharset'] = @$assoc_args['dbcharset'] ?: 'utf8';
-        $configArgs['dbcollate'] = @$assoc_args['dbcollate'] ?: '';
+        if (isset($assoc_args['dbcollate'])) $configArgs['dbcollate'] = $assoc_args['dbcollate'];
 
 
         // Create wp-config.php


### PR DESCRIPTION
Resolves #555 

This works around a WP-CLI issue on Windows where it (possibly incorrectly) treats `--dbcollate=""` as a positional argument. Linux quoting seems to be fine. (Maybe we could just use Linux quoting in VPCommandUtils::runWpCliCommand() but this small change is safer.)

Reviewers:
- [x] @JanVoracek 
