### PR TITLE
Options `page_on_front` and `page_for_posts` are now replaced by VPIDs

### DIFF
--- a/plugins/versionpress/src/Database/wordpress-schema.neon
+++ b/plugins/versionpress/src/Database/wordpress-schema.neon
@@ -61,3 +61,5 @@ option:
     value-references:
         option_name@option_value:
             site_icon: post
+            page_on_front: post
+            page_for_posts: post


### PR DESCRIPTION
Resolves #623.
