### PR TITLE
Configurable location of vpdb directory

### DIFF
--- a/plugins/versionpress/bootstrap.php
+++ b/plugins/versionpress/bootstrap.php
@@ -5,9 +5,14 @@ use Tracy\Debugger;
 use VersionPress\DI\DIContainer;
 
 define('VERSIONPRESS_PLUGIN_DIR', __DIR__);
-define('VERSIONPRESS_MIRRORING_DIR', WP_CONTENT_DIR . '/vpdb');
+
+if (!defined('VP_VPDB_DIR')) {
+    define('VP_VPDB_DIR', WP_CONTENT_DIR . '/vpdb');
+}
+
 define('VERSIONPRESS_TEMP_DIR', VERSIONPRESS_PLUGIN_DIR . '/temp');
-define('VERSIONPRESS_ACTIVATION_FILE', VERSIONPRESS_MIRRORING_DIR . '/.active');
+define('VERSIONPRESS_ACTIVATION_FILE', VP_VPDB_DIR . '/.active');
+
 if (!defined('VP_PROJECT_ROOT')) {
     define('VP_PROJECT_ROOT', ABSPATH);
 }

--- a/plugins/versionpress/src/Api/VersionPressApi.php
+++ b/plugins/versionpress/src/Api/VersionPressApi.php
@@ -377,7 +377,8 @@ class VersionPressApi {
 
         $status = $this->gitRepository->getStatus(true);
         if (ArrayUtils::any($status, function ($fileStatus) {
-            return Strings::contains($fileStatus[1], 'vpdb');
+            $vpdbName = basename(VP_VPDB_DIR);
+            return Strings::contains($fileStatus[1], $vpdbName);
         })) {
             $this->updateDatabase($status);
         }
@@ -389,7 +390,8 @@ class VersionPressApi {
     private function updateDatabase($status) {
         $diff = $this->gitRepository->getDiff();
         $vpidRegex = "/([\\da-f]{32})/i";
-        $optionRegex = "/.*vpdb[\\/\\\\]options[\\/\\\\].+[\\/\\\\](.+)\\.ini/i";
+        $vpdbName = basename(VP_VPDB_DIR);
+        $optionRegex = "/.*{$vpdbName}[\\/\\\\]options[\\/\\\\].+[\\/\\\\](.+)\\.ini/i";
 
         preg_match_all($vpidRegex, $diff, $vpidMatches);
         preg_match_all($optionRegex, $diff, $optionNameMatches);
@@ -515,7 +517,7 @@ class VersionPressApi {
 
         $changedFiles = array_filter($changedFiles, function ($changedFile) {
             $path = str_replace('\\', '/', ABSPATH . $changedFile['path']);
-            $vpdbPath = str_replace('\\', '/', VERSIONPRESS_MIRRORING_DIR);
+            $vpdbPath = str_replace('\\', '/', VP_VPDB_DIR);
 
             return !Strings::startsWith($path, $vpdbPath);
         });

--- a/plugins/versionpress/src/ChangeInfos/PluginChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/PluginChangeInfo.php
@@ -83,17 +83,17 @@ class PluginChangeInfo extends TrackedChangeInfo {
     }
 
     public function getChangedFiles() {
-        $path = WP_PLUGIN_DIR . "/";
+        $pluginPath = WP_PLUGIN_DIR . "/";
         if (dirname($this->pluginFile) == ".") {
             // single-file plugin like hello.php
-            $path .= $this->pluginFile;
+            $pluginPath .= $this->pluginFile;
         } else {
             // multi-file plugin like akismet/...
-            $path .= dirname($this->pluginFile) . "/*";
+            $pluginPath .= dirname($this->pluginFile) . "/*";
         }
-        $pluginChange = array("type" => "path", "path" => $path);
 
-        $optionChange = array("type" => "path", "path" => VERSIONPRESS_MIRRORING_DIR);
+        $pluginChange = array("type" => "path", "path" => $pluginPath);
+        $optionChange = array("type" => "path", "path" => VP_VPDB_DIR);
 
         return array($pluginChange, $optionChange);
     }

--- a/plugins/versionpress/src/ChangeInfos/VersionPressChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/VersionPressChangeInfo.php
@@ -85,7 +85,7 @@ class VersionPressChangeInfo extends TrackedChangeInfo {
         switch ($this->action) {
             case "deactivate":
                 return array(
-                    array("type" => "path", "path" => VERSIONPRESS_MIRRORING_DIR . "/*"),
+                    array("type" => "path", "path" => VP_VPDB_DIR . "/*"),
                     array("type" => "path", "path" => ABSPATH . WPINC . "/wp-db.php"),
                     array("type" => "path", "path" => ABSPATH . WPINC . "/wp-db.php.original"),
                 );

--- a/plugins/versionpress/src/DI/DIContainer.php
+++ b/plugins/versionpress/src/DI/DIContainer.php
@@ -59,7 +59,7 @@ class DIContainer {
         $dic->register(VersionPressServices::STORAGE_FACTORY, function () use ($dic) {
             global $wp_taxonomies;
             return new StorageFactory(
-                VERSIONPRESS_MIRRORING_DIR,
+                VP_VPDB_DIR,
                 $dic->resolve(VersionPressServices::DB_SCHEMA),
                 $dic->resolve(VersionPressServices::WPDB),
                 array_keys((array)$wp_taxonomies)

--- a/plugins/versionpress/src/Git/MergeDriverInstaller.php
+++ b/plugins/versionpress/src/Git/MergeDriverInstaller.php
@@ -12,7 +12,7 @@ class MergeDriverInstaller {
         $gitattributes = file_get_contents($directory . '/.gitattributes.tpl');
 
         $gitattributesVariables = array(
-            'vp-mirroring-dir' => rtrim(ltrim(PathUtils::getRelativePath(VP_PROJECT_ROOT, VERSIONPRESS_MIRRORING_DIR), '.'), '/\\')
+            'vpdb-dir' => rtrim(ltrim(PathUtils::getRelativePath(VP_PROJECT_ROOT, VP_VPDB_DIR), '.'), '/\\')
         );
         $gitattributes = "\n" . StringUtils::fillTemplateString($gitattributesVariables, $gitattributes);
 

--- a/plugins/versionpress/src/Git/Reverter.php
+++ b/plugins/versionpress/src/Git/Reverter.php
@@ -266,8 +266,9 @@ class Reverter {
     private function getAllVpIdsFromModifiedFiles($modifiedFiles) {
         $vpIds = array();
         $vpIdRegex = "/([\\da-f]{32})/i";
+        $vpdbName = basename(VP_VPDB_DIR);
         // https://regex101.com/r/yT6mF5/1
-        $optionFileRegex = "/.*vpdb[\\/\\\\]options[\\/\\\\].+[\\/\\\\](.+)\\.ini/i";
+        $optionFileRegex = "/.*{$vpdbName}[\\/\\\\]options[\\/\\\\].+[\\/\\\\](.+)\\.ini/i";
         // https://regex101.com/r/zC6dA2/2
         $optionNameRegex = "/^\\[(.*)\\]\\r?$/m";
 

--- a/plugins/versionpress/src/Initialization/.gitattributes.tpl
+++ b/plugins/versionpress/src/Initialization/.gitattributes.tpl
@@ -1,1 +1,1 @@
-{{vp-mirroring-dir}}/**/*.ini merge=vp-ini
+{{vpdb-dir}}/**/*.ini merge=vp-ini

--- a/plugins/versionpress/src/Initialization/Initializer.php
+++ b/plugins/versionpress/src/Initialization/Initializer.php
@@ -201,11 +201,11 @@ class Initializer {
      */
     private function saveDatabaseToStorages() {
 
-        if (is_dir(VERSIONPRESS_MIRRORING_DIR)) {
-            FileSystem::remove(VERSIONPRESS_MIRRORING_DIR);
+        if (is_dir(VP_VPDB_DIR)) {
+            FileSystem::remove(VP_VPDB_DIR);
         }
 
-        FileSystem::mkdir(VERSIONPRESS_MIRRORING_DIR);
+        FileSystem::mkdir(VP_VPDB_DIR);
 
         $entityNames = $this->synchronizerFactory->getSynchronizationSequence();
         foreach ($entityNames as $entityName) {
@@ -447,7 +447,7 @@ class Initializer {
      */
     private function copyAccessRulesFiles() {
         SecurityUtils::protectDirectory(VP_PROJECT_ROOT . "/.git");
-        SecurityUtils::protectDirectory(VERSIONPRESS_MIRRORING_DIR);
+        SecurityUtils::protectDirectory(VP_VPDB_DIR);
     }
 
     /**

--- a/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
+++ b/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
@@ -22,7 +22,7 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
         self::$repositoryDir = __DIR__ . '/repository';
 
         define('VERSIONPRESS_PLUGIN_DIR', self::$repositoryDir); // fake
-        define('VERSIONPRESS_MIRRORING_DIR', self::$repositoryDir); // fake
+        define('VP_VPDB_DIR', self::$repositoryDir); // fake
         define('VP_PROJECT_ROOT', self::$repositoryDir); // fake
   
 

--- a/plugins/versionpress/tests/LoadTests/MergeDriverLoadTest.php
+++ b/plugins/versionpress/tests/LoadTests/MergeDriverLoadTest.php
@@ -24,7 +24,7 @@ class MergeDriverLoadTest extends \PHPUnit_Framework_TestCase {
         self::$repositoryDir = __DIR__ . '/repository';
 
         define('VERSIONPRESS_PLUGIN_DIR', self::$repositoryDir); // fake
-        define('VERSIONPRESS_MIRRORING_DIR', self::$repositoryDir); // fake
+        define('VP_VPDB_DIR', self::$repositoryDir); // fake
         define('VP_PROJECT_ROOT', self::$repositoryDir); // fake
 
 

--- a/plugins/versionpress/tests/LoadTests/generate-files-and-commit.php
+++ b/plugins/versionpress/tests/LoadTests/generate-files-and-commit.php
@@ -59,7 +59,7 @@ class FooChangeInfo extends \VersionPress\ChangeInfos\TrackedChangeInfo {
 
 define('ABSPATH', __DIR__); // fake
 define('VERSIONPRESS_PLUGIN_DIR', __DIR__); // fake
-define('VERSIONPRESS_MIRRORING_DIR', __DIR__); // fake
+define('VP_VPDB_DIR', __DIR__); // fake
 $repositoryDir = __DIR__ . '/repository';
 
 $changeList = createFiles($repositoryDir, $args['from'], $args['to']);

--- a/plugins/versionpress/tests/Utils/DBAsserter.php
+++ b/plugins/versionpress/tests/Utils/DBAsserter.php
@@ -286,7 +286,7 @@ class DBAsserter {
         global $versionPressContainer, $wpdb;
 
         defined('VERSIONPRESS_PLUGIN_DIR') || define('VERSIONPRESS_PLUGIN_DIR', self::$testConfig->testSite->path . '/wp-content/plugins/versionpress');
-        defined('VERSIONPRESS_MIRRORING_DIR') || define('VERSIONPRESS_MIRRORING_DIR', self::$testConfig->testSite->path . '/wp-content/vpdb');
+        defined('VP_VPDB_DIR') || define('VP_VPDB_DIR', self::$testConfig->testSite->path . '/wp-content/vpdb');
         $versionPressContainer = DIContainer::getConfiguredInstance();
         $wpdb = self::$wpdb;
     }

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -53,7 +53,7 @@ if (!VersionPress::isActive() && is_file(VERSIONPRESS_PLUGIN_DIR . '/.abort-init
         FileSystem::remove(VP_PROJECT_ROOT . '/.git');
     }
 
-    FileSystem::remove(VERSIONPRESS_MIRRORING_DIR);
+    FileSystem::remove(VP_VPDB_DIR);
     unlink(VERSIONPRESS_PLUGIN_DIR . '/.abort-initialization');
 }
 
@@ -664,7 +664,7 @@ function vp_admin_post_confirm_deactivation() {
         FileSystem::remove(VERSIONPRESS_ACTIVATION_FILE);
     }
 
-    FileSystem::remove(VERSIONPRESS_MIRRORING_DIR);
+    FileSystem::remove(VP_VPDB_DIR);
 
 
     global $versionPressContainer;


### PR DESCRIPTION
Resolves #656 

I also changed the name of the constant – from `VERSIONPRESS_MIRRORING_DIR` to `VP_VPDB_DIR`. It's simpler and matches the style with `VP_PROJECT_ROOT`.

(Note: we currently have two "public" constants, `VP_VPDB_DIR` and `VP_PROJECT_ROOT`, and a couple of private ones which are usually prefixed `VERSIONPRESS_`. We'll stick to this convention.)

Some docs is required (maybe we could make label for this?).

Reviewers:
- [x] @borekb 
- [x] @octopuss 
