### PR TITLE
Avoid 777 permissions on .git directory

### DIFF
--- a/plugins/versionpress/src/Utils/FileSystem.php
+++ b/plugins/versionpress/src/Utils/FileSystem.php
@@ -110,7 +110,7 @@ class FileSystem {
 
     /**
      * If the path is either a `.git` repository itself or a directory that contains it,
-     * this method attempts to set 0777 permissions on the `.git` folder to avoid issues
+     * this method attempts to set correct permissions on the `.git` folder to avoid issues
      * on Windows.
      *
      * @param $path
@@ -131,7 +131,11 @@ class FileSystem {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($gitDir));
 
             foreach ($iterator as $item) {
-                chmod($item, 0777);
+                if (is_dir($item)) {
+                    chmod($item, 0750);
+                } else {
+                    chmod($item, 0640);
+                }
             }
 
         }


### PR DESCRIPTION
Resolves #663.

We'll go with 640 for files and 750 for directories as WordPress [used to](https://core.trac.wordpress.org/changeset/25739) until 2013. It seems best.

We're not sure about Windows. We used to have 777 in our code for some reason (see #184) but forgot the details.

Reviewers:
- [x] @borekb 
- [x] @octopuss 
