### PR TITLE
Make Customizer changes more descriptive

### DIFF
--- a/plugins/versionpress/src/ChangeInfos/ThemeChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/ThemeChangeInfo.php
@@ -10,10 +10,10 @@ use VersionPress\Utils\StringUtils;
  *
  * VP tags:
  *
- *     VP-Action: theme/(install|update|customize|edit|switch|delete)/twentyfourteen
+ *     VP-Action: theme/(install|update|edit|switch|delete)/twentyfourteen
  *     VP-Theme-Name: Twenty Fourteen
  *
- * Note: theme is `customize`d via the WP customizer, `edit`ed via the built in text editor.
+ * Note: theme is `edit`ed via the built in text editor.
  *
  */
 class ThemeChangeInfo extends TrackedChangeInfo {

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -234,15 +234,6 @@ function vp_register_hooks() {
         $committer->forceChangeInfo(new ThemeChangeInfo($stylesheet, 'switch', $themeName));
     });
 
-    add_action('customize_save_after', function ($customizeManager) use ($committer) {
-        /** @var WP_Customize_Manager $customizeManager */
-        $stylesheet = $customizeManager->theme()->get_stylesheet();
-        $committer->forceChangeInfo(new ThemeChangeInfo($stylesheet, 'customize'));
-        register_shutdown_function(function () {
-            wp_remote_get(admin_url("admin.php"));
-        });
-    });
-
     add_action('untrashed_post_comments', function ($postId) use ($wpdb, $dbSchemaInfo, $wpdbMirrorBridge) {
         $commentsTable = $dbSchemaInfo->getPrefixedTableName("comment");
         $commentStatusSql = "select comment_ID, comment_approved from {$commentsTable} where comment_post_ID = {$postId}";
@@ -400,10 +391,9 @@ function vp_register_hooks() {
     }, 10, 2);
 
     add_action('before_delete_post', function ($postId) use ($wpdb) {
-            // Fixing bug in WP (#34803) and WP-CLI (#2246)
+        // Fixing bug in WP (#34803) and WP-CLI (#2246)
         $post = get_post($postId);
         if ( !is_wp_error($post) && $post->post_type === 'nav_menu_item' ) {
-            \Tracy\Debugger::log('Deleting menu item ' . $post->ID);
             $newParent = get_post_meta($post->ID, '_menu_item_menu_item_parent', true);
             $wpdb->update($wpdb->postmeta,
                 array('meta_value' => $newParent),


### PR DESCRIPTION
Resolves #432.

It looks like removing the special action for customizer is enough. It was introduced in #88. Probably because the old GUI displayed only first change, which was confusing.

Reviewers:
- [x] @borekb 
- [x] @octopuss 
