### PR TITLE
Check PHP extensions in RequirementsChecker

### DIFF
--- a/plugins/versionpress/src/Utils/RequirementsChecker.php
+++ b/plugins/versionpress/src/Utils/RequirementsChecker.php
@@ -53,7 +53,7 @@ class RequirementsChecker {
         );
 
         $this->requirements[] = array(
-            'name' => 'PHP extensions',
+            'name' => "'mbstring' extension",
             'level' => 'critical',
             'fulfilled' => extension_loaded('mbstring'),
             'help' => 'Extension `mbstring` is required.'


### PR DESCRIPTION
Resolves #671.

It looks like `mbstring` is the only required php extension. NEON parser requires `iconv` but we will replace NEON with YAML, see https://github.com/versionpress/versionpress/issues/703.

Reviewers:
- [x] @borekb 
- [x] @octopuss 
