### PR TITLE
Fixed requiring of `shortcodes.php` in tests

### DIFF
--- a/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
+++ b/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
@@ -42,7 +42,10 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase {
 
         /** @var $wp_db_version */
         require(self::$testConfig->testSite->path . '/wp-includes/version.php');
-        require_once(self::$testConfig->testSite->path . '/wp-includes/shortcodes.php');
+
+        if (!function_exists('get_shortcode_regex')) {
+            require_once(self::$testConfig->testSite->path . '/wp-includes/shortcodes.php');
+        }
 
         self::$schemaInfo = new DbSchemaInfo($schemaFile, self::$testConfig->testSite->dbTablePrefix, $wp_db_version);
 
@@ -55,7 +58,7 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase {
 
         $shortcodesInfo = new ShortcodesInfo($shortcodeFile);
         $vpidRepository = new VpidRepository(self::$wpdb, self::$schemaInfo);
-        self::$shortcodesReplacer = new ShortcodesReplacer($shortcodesInfo,$vpidRepository);
+        self::$shortcodesReplacer = new ShortcodesReplacer($shortcodesInfo, $vpidRepository);
 
         $vpdbPath = self::$testConfig->testSite->path . '/wp-content/vpdb';
         self::$storageFactory = new StorageFactory($vpdbPath, self::$schemaInfo, self::$wpdb, array());

--- a/plugins/versionpress/tests/Unit/ShortcodesReplacerTest.php
+++ b/plugins/versionpress/tests/Unit/ShortcodesReplacerTest.php
@@ -24,7 +24,9 @@ class ShortcodesReplacerTest extends \PHPUnit_Framework_TestCase {
     private $vpidRepository;
 
     protected function setUp() {
-        include_once '../../../../ext-libs/wordpress/wp-includes/shortcodes.php';
+        if (!function_exists('get_shortcode_regex')) {
+            include_once __DIR__ . '/../../../../ext-libs/wordpress/wp-includes/shortcodes.php';
+        }
 
         $this->shortcodesInfo = $this->getMockBuilder('VersionPress\Database\ShortcodesInfo')->disableOriginalConstructor()->getMock();
         $this->shortcodesInfo->expects($this->any())->method('getAllShortcodeNames')->will($this->returnValue(array_column($this->shortcodeSchemaValueMap, 0)));

--- a/plugins/versionpress/tests/Utils/DBAsserter.php
+++ b/plugins/versionpress/tests/Utils/DBAsserter.php
@@ -47,7 +47,10 @@ class DBAsserter {
 
         /** @var $wp_db_version */
         require(self::$testConfig->testSite->path . '/wp-includes/version.php');
-        require_once(self::$testConfig->testSite->path . '/wp-includes/shortcodes.php');
+
+        if (!function_exists('get_shortcode_regex')) {
+            require_once(self::$testConfig->testSite->path . '/wp-includes/shortcodes.php');
+        }
 
         self::$schemaInfo = new DbSchemaInfo($schemaFile, self::$testConfig->testSite->dbTablePrefix, $wp_db_version);
 


### PR DESCRIPTION
Resolves #654.

Reviewers:
- [x] @borekb 
