### PR TITLE
Failing deactivation test

### DIFF
--- a/plugins/versionpress/admin/deactivate.php
+++ b/plugins/versionpress/admin/deactivate.php
@@ -20,7 +20,7 @@ function _vp_button($label, $action, $type = "delete", $cssClass = "") {
     echo "<form action='" . esc_url(admin_url('admin-post.php')) . "' method='post' class='" . esc_attr($cssClass) . "'>";
     echo "<input type='hidden' name='action' value='$action' />";
     submit_button($label, $type, $action, false, $other_attributes = array("id" => $action));
-    wp_nonce_field('vp_deactivation');
+    wp_nonce_field('deactivate-plugin_versionpress/versionpress.php');
     echo "</form>";
 }
 

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -618,8 +618,9 @@ function vp_admin_post_cancel_deactivation() {
  * or is called directly from vp_deactivate() if the confirmation screen was not necessary.
  */
 function vp_admin_post_confirm_deactivation() {
-
-    vp_verify_nonce('vp_deactivation');
+    //nonce verification is performed according to 'deactivate-plugin_versionpress/versionpress.php'
+    // as a standard deactivation token for which nonce is generated
+    vp_verify_nonce('deactivate-plugin_versionpress/versionpress.php');
     vp_check_permissions();
 
     define('VP_DEACTIVATING', true);


### PR DESCRIPTION
Closes #791 by changing string used for  `nonce` generation when plugin is deactivated 

Please review : 
- [x] @JanVoracek 

Thank you.
