### PR TITLE
Unnecessary saves of post

### DIFF
--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -531,18 +531,18 @@ function vp_create_update_post_terms_hook(Mirror $mirror, VpidRepository $vpidRe
         $postVpId = $vpidRepository->getVpidForEntity('post', $postId);
 
         $postUpdateData = array('vp_id' => $postVpId, 'vp_term_taxonomy' => array());
-        $taxonomies_terms = [];
+        $postRelatedTerms = [];
         foreach ($taxonomies as $taxonomy) {
             $terms = get_the_terms($postId, $taxonomy);
             if ($terms) {
                 $referencedTaxonomies = array_map(function ($term) use ($vpidRepository) {
                     return $vpidRepository->getVpidForEntity('term_taxonomy', $term->term_taxonomy_id);
                 }, $terms);
-                $taxonomies_terms[] = $terms;
+                $postRelatedTerms[] = $terms;
                 $postUpdateData['vp_term_taxonomy'] = array_merge($postUpdateData['vp_term_taxonomy'], $referencedTaxonomies);
             }
         }
-        if (count($taxonomies) > 0 && count($taxonomies_terms) > 0) {
+        if (count($taxonomies) > 0 && count($postRelatedTerms) > 0) {
             $mirror->save("post", $postUpdateData);
         }
     };


### PR DESCRIPTION
PR solves unnecessary saves of post when there are no `$terms` for it. 

Please review it. Closes #712.
- [x] @JanVoracek 
- [x] @borekb 

Thank you.
