### PR TITLE
Full diff not shown

### DIFF
--- a/frontend/src/Commits/DiffPanel.react.tsx
+++ b/frontend/src/Commits/DiffPanel.react.tsx
@@ -59,7 +59,7 @@ export default class DiffPanel extends React.Component<DiffPanelProps, any> {
       return <span />;
     };
 
-    let lineDiff = JsDiff.diffWords(leftContent, rightContent);
+    let lineDiff = JsDiff.diffWordsWithSpace(leftContent, rightContent);
 
     leftContent = lineDiff.map(diffPart => highlightLine(diffPart, () => !!diffPart.removed, '#f8cbcb'));
     rightContent = lineDiff.map(diffPart => highlightLine(diffPart, () => !!diffPart.added, '#a6f3a6'));


### PR DESCRIPTION
I've solved issue #622 by changing whitespace to be significant when creating diff for client display (see. `JsDiff.diffWordsWithSpace` from [diff library](https://www.npmjs.com/package/diff). 

To reproduce and test it, add empty line at the end of any `ini` file created by VersionPress. Commit the change, then open the file again, in simple text editor (not IDE with whitespace trimming) and change blank line content to " ". Before this change, viewing of diff of this commit will fail in VersionPress gui. After this change it should work. Example diff is shown below.

<img width="689" alt="screen shot 2016-03-25 at 5 39 43 pm" src="https://cloud.githubusercontent.com/assets/2697437/14064570/13000914-f408-11e5-81dc-296b798d6886.png">

Frontend needs to be rebuild to apply this change.

Please review:
- [x] @JanVoracek 

Thank you.
