### PR TITLE
Some options are not mapped to VPID

### DIFF
--- a/plugins/versionpress/src/Database/wordpress-schema.yml
+++ b/plugins/versionpress/src/Database/wordpress-schema.yml
@@ -76,6 +76,9 @@ option:
             site_icon: post
             page_on_front: post
             page_for_posts: post
+            default_category: term_taxonomy
+            default_link_category: term_taxonomy
+            default_email_category: term_taxonomy
     frequently-written:
         - 'option_name: akismet_spam_count'
     ignored-entities:


### PR DESCRIPTION
PR resolves #819 with its reduced scope. Only 
-  default_category
-  default_link_category
-  default_email_category
  are mapped.

Please review: 
- [x] @JanVoracek 

Thank you.
