### PR TITLE
ext-lib WordPress changed from fixed version to `*`

### DIFF
--- a/ext-libs/composer.json
+++ b/ext-libs/composer.json
@@ -3,7 +3,7 @@
     "description": "Libraries referenced by PhpStorm but not actually dependencies",
     "minimum-stability": "beta",
     "require-dev": {
-        "johnpbloch/wordpress": "~4.4",
+        "johnpbloch/wordpress": "*",
         "wp-cli/wp-cli": "~0.22"
     },
     "extra": {


### PR DESCRIPTION
Resolves #838 

Change based on https://github.com/versionpress/versionpress/issues/838#issuecomment-204146026

Reviewers:
- [x] @JanVoracek 
