### PR TITLE
Failing wp-cli VersionPress deactivation

### DIFF
--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -624,8 +624,10 @@ function vp_admin_post_cancel_deactivation() {
 function vp_admin_post_confirm_deactivation() {
     //nonce verification is performed according to 'deactivate-plugin_versionpress/versionpress.php'
     // as a standard deactivation token for which nonce is generated
-    vp_verify_nonce('deactivate-plugin_versionpress/versionpress.php');
-    vp_check_permissions();
+    if (!defined('WP_CLI')) {
+        vp_verify_nonce('deactivate-plugin_versionpress/versionpress.php');
+        vp_check_permissions();
+    }
 
     define('VP_DEACTIVATING', true);
 


### PR DESCRIPTION
Permissions and `nonce` was checked also for `wp plugin deactivate`. PR resolves #843.

Please review:
- [x] @JanVoracek 

Thank you.
