### PR TITLE
Disable tracking of `default_link_category`

### DIFF
--- a/plugins/versionpress/src/Database/wordpress-schema.yml
+++ b/plugins/versionpress/src/Database/wordpress-schema.yml
@@ -92,7 +92,6 @@ option:
       page_on_front: post
       page_for_posts: post
       default_category: term_taxonomy
-      default_link_category: term_taxonomy
       default_email_category: term_taxonomy
       widget_nav_menu[/\d+/]["nav_menu"]: term
       widget_pages[/\d+/]["exclude"]: post


### PR DESCRIPTION
Resolves #865  .

Removing tracking of `default_link_category` from `wordpress-schema.yml`

Reviewers:

- [x] @JanVoracek 

Thank you.