### PR TITLE
Spam comment should not commit

### DIFF
--- a/plugins/versionpress/src/Database/wordpress-schema.yml
+++ b/plugins/versionpress/src/Database/wordpress-schema.yml
@@ -38,8 +38,8 @@ comment:
     comment_post_ID: post
     user_id: user
     comment_parent: comment
-    ignored-entities:
-      - 'comment_approved: spam'
+  ignored-entities:
+    - 'comment_approved: spam'
 
 commentmeta:
   table: commentmeta

--- a/plugins/versionpress/src/Storages/CommentStorage.php
+++ b/plugins/versionpress/src/Storages/CommentStorage.php
@@ -23,11 +23,9 @@ class CommentStorage extends DirectoryStorage {
 
         if ($isExistingEntity && $data['comment_approved'] === 'spam') {
             return true;
-        } else if(!$isExistingEntity && $data['comment_approved'] === 'spam') {
-            return false;
-        } else {
-            return parent::shouldBeSaved($data);
         }
+
+        return parent::shouldBeSaved($data);
     }
 
     protected function createChangeInfo($oldEntity, $newEntity, $action = null) {

--- a/plugins/versionpress/src/Storages/CommentStorage.php
+++ b/plugins/versionpress/src/Storages/CommentStorage.php
@@ -23,9 +23,11 @@ class CommentStorage extends DirectoryStorage {
 
         if ($isExistingEntity && $data['comment_approved'] === 'spam') {
             return true;
+        } else if(!$isExistingEntity && $data['comment_approved'] === 'spam') {
+            return false;
+        } else {
+            return parent::shouldBeSaved($data);
         }
-
-        return parent::shouldBeSaved($data);
     }
 
     protected function createChangeInfo($oldEntity, $newEntity, $action = null) {


### PR DESCRIPTION
Resolves #869 .

Wrong padding in file caused `ignored-entities` for comments to be handled incorrectly.

Reviewers:

- [x] @JanVoracek 

Thank you.