### PR TITLE
Removing menu item with children

### DIFF
--- a/plugins/versionpress/src/Database/WpdbMirrorBridge.php
+++ b/plugins/versionpress/src/Database/WpdbMirrorBridge.php
@@ -210,7 +210,7 @@ class WpdbMirrorBridge {
 
         $table = $this->dbSchemaInfo->getPrefixedTableName($entityName);
         $idColumnName = $this->dbSchemaInfo->getEntityInfo($entityName)->idColumnName;
-        $data = $this->database->get_row("SELECT * FROM `$table` WHERE `$idColumnName` = '$id'", ARRAY_A);
+        $data = array_merge($this->database->get_row("SELECT * FROM `$table` WHERE `$idColumnName` = '$id'", ARRAY_A), $data);
 
         $data['vp_id'] = $vpId;
         $data = $this->vpidRepository->replaceForeignKeysWithReferences($entityName, $data);

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -373,15 +373,16 @@ function vp_register_hooks() {
         $wpdbMirrorBridge->update($database->term_taxonomy, array('parent' => $term->parent), array('parent' => $term->term_id));
     }, 10, 2);
 
-    add_action('before_delete_post', function ($postId) use ($database) {
+    add_action('before_delete_post', function ($postId) use ($database, $wpdbMirrorBridge) {
         // Fixing bug in WP (#34803) and WP-CLI (#2246);
-        // this is rare case where $wpdb must be used, not $database
-        global $wpdb;
-
         $post = get_post($postId);
         if (!is_wp_error($post) && $post->post_type === 'nav_menu_item') {
             $newParent = get_post_meta($post->ID, '_menu_item_menu_item_parent', true);
-            $wpdb->update($wpdb->postmeta,
+            $wpdbMirrorBridge->update($database->postmeta,
+                array('meta_value' => $newParent),
+                array('meta_key' => '_menu_item_menu_item_parent', 'meta_value' => $post->ID)
+            );
+            $database->update($database->postmeta,
                 array('meta_value' => $newParent),
                 array('meta_key' => '_menu_item_menu_item_parent', 'meta_value' => $post->ID)
             );


### PR DESCRIPTION
Resolves #870.

We need at first change the storage and then the database because the DB update changes columns used in restriction.

Reviewers:
- [x] @octopuss 
