### PR TITLE
Missing environment when committing through VP admin

### DIFF
--- a/plugins/versionpress/src/ChangeInfos/ChangeInfoMatcher.php
+++ b/plugins/versionpress/src/ChangeInfos/ChangeInfoMatcher.php
@@ -50,10 +50,6 @@ class ChangeInfoMatcher {
      * @return ChangeInfoEnvelope|UntrackedChangeInfo
      */
     public static function buildChangeInfo(CommitMessage $commitMessage) {
-        if (self::findMatchingChangeInfo($commitMessage) === 'VersionPress\ChangeInfos\UntrackedChangeInfo') {
-            return UntrackedChangeInfo::buildFromCommitMessage($commitMessage);
-        }
-
         return ChangeInfoEnvelope::buildFromCommitMessage($commitMessage);
     }
 


### PR DESCRIPTION
Resolves #895.

Manual commits now contain the environment, version of VP and overview displays changed INI files in `vpdb`.

Reviewers:
- [x] @octopuss 