### PR TITLE
Uncommitted changes - CSS glitch for inactive select boxes

### DIFF
--- a/frontend/src/Commits/CommitsTable.less
+++ b/frontend/src/Commits/CommitsTable.less
@@ -100,6 +100,7 @@
     padding: 0 !important;
     overflow: visible !important;
     width: 12px;
+    z-index: 2;
 
     div {
       position: absolute;


### PR DESCRIPTION
Resolves #888.

Fixed environment z-index to be rendered above the checkbox.

Reviewers:

- [ ] @pavelevap 
