### PR TITLE
Empty sections in `.git/config`

### DIFF
--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -969,21 +969,6 @@ class VPCommand extends WP_CLI_Command {
         WP_CLI::success("wp-config.php updated");
     }
 
-    private static function updateConfigConstant($config, $constant, $value) {
-        // https://regex101.com/r/zD3mJ4/3 - just remove the "g" modifier which is there for testing only
-        $re = "/(define\\s*\\(\\s*['\"]{$constant}['\"]\\s*,\\s*['\"]).*(['\"]\\s*\\)\\s*;)/m";
-        return preg_replace($re, "\${1}{$value}\${2}", $config, 1);
-    }
-
-    private static function createConfigConstant($config, $constant, $value) {
-        $tablePrefixPos = strpos($config, 'table_prefix');
-        $lineAfterTablePrefixPos = strpos($config, "\n", $tablePrefixPos) + 1;
-
-        $constantDefinition = "define('$constant', '$value');\n";
-
-        return substr($config, 0, $lineAfterTablePrefixPos) . $constantDefinition . substr($config, $lineAfterTablePrefixPos);
-    }
-
     /**
      * Returns URL for a remote name, or null if the remote isn't configured.
      * For example, for "origin", it might return "https://github.com/project/repo.git".

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -124,7 +124,10 @@ class VPCommand extends WP_CLI_Command {
 
         defined('SHORTINIT') or define('SHORTINIT', true);
 
-        $this->requireWpConfig();
+        $wpConfigPath = \WP_CLI\Utils\locate_wp_config();
+        $commonConfigName = 'wp-config.common.php';
+
+        $this->requireWpConfig($wpConfigPath, $commonConfigName);
 
         require_once __DIR__ . '/../../bootstrap.php';
 
@@ -192,7 +195,10 @@ class VPCommand extends WP_CLI_Command {
 
         defined('SHORTINIT') or define('SHORTINIT', true);
 
-        $this->requireWpConfig();
+        $wpConfigPath = \WP_CLI\Utils\locate_wp_config();
+        $commonConfigName = 'wp-config.common.php';
+
+        $this->requireWpConfig($wpConfigPath, $commonConfigName);
         require_once __DIR__ . '/../../bootstrap.php';
 
         if (!VersionPress::isActive()) {
@@ -1098,9 +1104,7 @@ class VPCommand extends WP_CLI_Command {
     /**
      * Tries to require Wordpress config files. Throws WP-CLI error when files not found.
      */
-    private function requireWpConfig() {
-        $wpConfigPath = \WP_CLI\Utils\locate_wp_config();
-        $commonConfigName = 'wp-config.common.php';
+    private function requireWpConfig($wpConfigPath, $commonConfigName) {
         $commonConfigPath = dirname($wpConfigPath) . '/' . $commonConfigName;
         if (file_exists($wpConfigPath)) {
             require_once $wpConfigPath;

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -11,6 +11,7 @@ use Nette\Utils\Strings;
 use Symfony\Component\Filesystem\Exception\IOException;
 use VersionPress\Database\DbSchemaInfo;
 use VersionPress\DI\VersionPressServices;
+use VersionPress\Git\GitConfig;
 use VersionPress\Git\GitRepository;
 use VersionPress\Git\Reverter;
 use VersionPress\Git\RevertStatus;
@@ -750,6 +751,9 @@ class VPCommand extends WP_CLI_Command {
         } else {
             VPCommandUtils::exec("git config --local push.default $currentPushType");
         }
+
+        $gitConfigPath = VP_PROJECT_ROOT . '/.git/config';
+        GitConfig::removeEmptySections($gitConfigPath);
 
         $process = $this->runVPInternalCommand('finish-push', array(), $remotePath);
         if ($process->isSuccessful()) {

--- a/plugins/versionpress/src/Git/GitConfig.php
+++ b/plugins/versionpress/src/Git/GitConfig.php
@@ -5,4 +5,14 @@ namespace VersionPress\Git;
 class GitConfig {
     public static $wpcliUserName = "WP-CLI";
     public static $wpcliUserEmail = "wpcli@localhost";
+
+    public static function removeEmptySections($gitConfigPath) {
+        $gitConfigContent = file_get_contents($gitConfigPath);
+
+        // https://regex101.com/r/nD0zI5/2
+        $re = "/\\[[^\\[]+\\]\\r?\\n(?=\\[)/";
+        $gitConfigContent = preg_replace($re, '', $gitConfigContent);
+
+        file_put_contents($gitConfigPath, $gitConfigContent);
+    }
 }

--- a/plugins/versionpress/src/Git/GitRepository.php
+++ b/plugins/versionpress/src/Git/GitRepository.php
@@ -90,6 +90,9 @@ class GitRepository {
         } else {
             $this->runShellCommand('git config --local user.email %s', $localConfigUserEmail);
         }
+
+        $gitConfigPath = $this->workingDirectoryRoot . '/.git/config';
+        GitConfig::removeEmptySections($gitConfigPath);
     }
 
     /**


### PR DESCRIPTION
Resolves #921.

All empty sections are now removed on commit and push. I also fixed a small bug in the `restore-site` command. I needed it for testing so it's part of this PR.

Reviewers:
- [x] @octopuss 