### PR TITLE
MergeDriverLoadTest is now fast by default

### DIFF
--- a/plugins/versionpress/tests/LoadTests/MergeDriverLoadTest.php
+++ b/plugins/versionpress/tests/LoadTests/MergeDriverLoadTest.php
@@ -10,6 +10,12 @@ class MergeDriverLoadTest extends \PHPUnit_Framework_TestCase {
 
     private static $repositoryDir;
 
+    /**
+     * !!! INCREASE THIS to something like 100 or 1000 to get more real-world results.
+     * The default is low so that if someone accidentally runs all tests, it doesn't block it.
+     */
+    const ITERATIONS = 1;
+
     public static function setUpBeforeClass() {
         self::$repositoryDir = __DIR__ . '/repository';
     }
@@ -73,19 +79,17 @@ class MergeDriverLoadTest extends \PHPUnit_Framework_TestCase {
     }
 
     private function prepareTestRepositoryHistory() {
-        $limit = 1000;
-
-        for ($i = 0; $i < $limit; $i++) {
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
             MergeDriverTestUtils::writeIniFile('file' . $i . '.ini', '2011-11-11 11:11:11');
         }
         MergeDriverTestUtils::commit('Initial commit to Ancestor');
         MergeDriverTestUtils::runGitCommand('git checkout -b test-branch');
-        for ($i = 0; $i < $limit; $i++) {
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
             MergeDriverTestUtils::writeIniFile('file' . $i . '.ini', '2012-12-12 12:12:12', 'Custom content');
         }
         MergeDriverTestUtils::commit('Commit to branch');
         MergeDriverTestUtils::runGitCommand('git checkout master');
-        for ($i = 0; $i < $limit; $i++) {
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
             MergeDriverTestUtils::writeIniFile('file' . $i . '.ini', '2013-03-03 13:13:13');
         }
         MergeDriverTestUtils::commit('Commit to master');


### PR DESCRIPTION
A quick PR without an issue.

MergeDriverLoadTest now executes almost instantly which is useful if someone runs the whole `tests` folder. To actually get some load test results, one needs to update the `ITERATIONS` constant in MergeDriverLoadTest which is probably fine because the results of this test need to inspected manually anyway.

Reviewers:

- [x] @JanVoracek 
- [x] @octopuss 