### PR TITLE
DbAsserter is more strict when comparing stored values against database

### DIFF
--- a/plugins/versionpress/src/Database/WpdbMirrorBridge.php
+++ b/plugins/versionpress/src/Database/WpdbMirrorBridge.php
@@ -50,9 +50,9 @@ class WpdbMirrorBridge {
         $entityName = $entityInfo->entityName;
         $data = $this->vpidRepository->replaceForeignKeysWithReferences($entityName, $data);
 
-        array_walk($data, function (&$key, $value) {
+        array_walk($data, function (&$value, $key) {
             if ($value === false) {
-                $key = '';
+                $value = '';
             }
         });
 

--- a/plugins/versionpress/src/Database/WpdbMirrorBridge.php
+++ b/plugins/versionpress/src/Database/WpdbMirrorBridge.php
@@ -49,6 +49,13 @@ class WpdbMirrorBridge {
 
         $entityName = $entityInfo->entityName;
         $data = $this->vpidRepository->replaceForeignKeysWithReferences($entityName, $data);
+
+        array_walk($data, function (&$key, $value) {
+            if ($value === false) {
+                $key = '';
+            }
+        });
+
         $shouldBeSaved = $this->mirror->shouldBeSaved($entityName, $data);
 
         if (!$shouldBeSaved) {
@@ -73,6 +80,12 @@ class WpdbMirrorBridge {
 
         $entityName = $entityInfo->entityName;
         $data = array_merge($where, $data);
+
+        array_walk($data, function (&$value, $key) {
+            if ($value === false) {
+                $value = '';
+            }
+        });
 
         if (!$entityInfo->usesGeneratedVpids) { // options etc.
             $data = $this->vpidRepository->replaceForeignKeysWithReferences($entityName, $data);

--- a/plugins/versionpress/src/Database/wordpress-schema.yml
+++ b/plugins/versionpress/src/Database/wordpress-schema.yml
@@ -75,6 +75,8 @@ term_taxonomy:
     term_id: term
   mn-references:
     ~term_relationships.object_id: post
+  ignored-columns:
+    - count: '@\VersionPress\Synchronizers\TermTaxonomiesSynchronizer::fixPostsCount'
 
 usermeta:
   id: umeta_id
@@ -123,4 +125,7 @@ option:
     - 'option_name: auth_salt'
     - 'option_name: logged_in_key'
     - 'option_name: logged_in_salt'
+    - 'option_name: theme_switched'
     # All {$taxonomy}_children are also ignored - see OptionStorage
+  ignored-columns:
+    - option_id

--- a/plugins/versionpress/src/Storages/TermTaxonomyStorage.php
+++ b/plugins/versionpress/src/Storages/TermTaxonomyStorage.php
@@ -15,12 +15,6 @@ class TermTaxonomyStorage extends DirectoryStorage {
         $this->termStorage = $termStorage;
     }
 
-    protected function removeUnwantedColumns($entity) {
-        $entity = parent::removeUnwantedColumns($entity);
-        unset($entity['count']);
-        return $entity;
-    }
-
     protected function createChangeInfo($oldEntity, $newEntity, $action) {
         $taxonomy = isset($newEntity['taxonomy']) ? $newEntity['taxonomy'] : $oldEntity['taxonomy'];
         $vpid = isset($newEntity['vp_id']) ? $newEntity['vp_id'] : $oldEntity['vp_id'];

--- a/plugins/versionpress/src/Synchronizers/TermTaxonomiesSynchronizer.php
+++ b/plugins/versionpress/src/Synchronizers/TermTaxonomiesSynchronizer.php
@@ -2,6 +2,7 @@
 
 namespace VersionPress\Synchronizers;
 
+use VersionPress\Database\Database;
 use VersionPress\Database\DbSchemaInfo;
 use VersionPress\Database\ShortcodesReplacer;
 use VersionPress\Storages\Storage;
@@ -19,22 +20,17 @@ class TermTaxonomiesSynchronizer extends SynchronizerBase {
     }
 
     protected function doEntitySpecificActions() {
-        if ($this->passNumber == 1) {
-            return false;
-        }
-
-        $this->fixPostsCount();
-        $this->clearCache();
+        WordPressCacheUtils::clearTermCache(array_column($this->entities, 'vp_term_id'), $this->database);
         return true;
     }
 
-    private function fixPostsCount() {
-        $sql = "update {$this->database->term_taxonomy} tt set tt.count =
-          (select count(*) from {$this->database->term_relationships} tr where tr.term_taxonomy_id = tt.term_taxonomy_id);";
-        $this->database->query($sql);
+    /**
+     * @param Database $database
+     */
+    public static function fixPostsCount($database) {
+        $sql = "update {$database->term_taxonomy} tt set tt.count =
+          (select count(*) from {$database->term_relationships} tr where tr.term_taxonomy_id = tt.term_taxonomy_id);";
+        $database->query($sql);
     }
 
-    private function clearCache() {
-        WordPressCacheUtils::clearTermCache(array_column($this->entities, 'vp_term_id'), $this->database);
-    }
 }

--- a/plugins/versionpress/tests/SynchronizerTests/Utils/EntityUtils.php
+++ b/plugins/versionpress/tests/SynchronizerTests/Utils/EntityUtils.php
@@ -8,7 +8,7 @@ use VersionPress\Utils\IdUtil;
 class EntityUtils {
 
     public static function prepareOption($name, $value) {
-        return array('option_name' => $name, 'option_value' => $value);
+        return array('option_name' => $name, 'option_value' => $value, 'autoload' => 'yes');
     }
 
     public static function prepareUser($vpId = null, $userValues = array()) {
@@ -38,6 +38,8 @@ class EntityUtils {
         $post = array_merge(array(
             'post_date' => "2015-02-02 14:19:59",
             'post_date_gmt' => "2015-02-02 14:19:59",
+            'post_modified' => '0000-00-00 00:00:00',
+            'post_modified_gmt' => '0000-00-00 00:00:00',
             'post_content' => "Welcome to WordPress. This is your first post. Edit or delete it, then start blogging!",
             'post_title' => "Hello world!",
             'post_excerpt' => "",
@@ -54,6 +56,8 @@ class EntityUtils {
             'post_type' => "post",
             'post_mime_type' => "",
             'vp_id' => $vpId,
+            'vp_post_parent' => 0,
+            'vp_post_author' => 0,
         ), $postValues);
 
         if ($authorVpId !== null) {
@@ -121,8 +125,15 @@ class EntityUtils {
             'comment_author_email' => 'joetester@example.com',
             'comment_author_url' => '',
             'comment_date' => '2012-12-12 12:12:12',
+            'comment_date_gmt' => '0000-00-00 00:00:00',
             'comment_content' => 'Some content',
             'comment_approved' => 1,
+            'comment_author_IP' => '',
+            'comment_karma' => 0,
+            'comment_agent' => '',
+            'comment_type' => '',
+            'comment_parent' => 0,
+            'vp_comment_parent' => 0,
             'vp_id' => $vpId,
         ), $commentValues);
 
@@ -180,6 +191,8 @@ class EntityUtils {
         if ($description !== null) {
             $termTaxonomy['description'] = $description;
         }
+
+        $termTaxonomy['vp_parent'] = 0;
 
         return $termTaxonomy;
 

--- a/plugins/versionpress/tests/Utils/DBAsserter.php
+++ b/plugins/versionpress/tests/Utils/DBAsserter.php
@@ -120,8 +120,11 @@ class DBAsserter {
             $dbEntity = self::$shortcodesReplacer->replaceShortcodesInEntity($entityName, $dbEntity);
 
             foreach ($dbEntity as $column => $value) {
-                if (!isset($storageEntity[$column])) {
+                if ($entityInfo->idColumnName === $column || isset($entityInfo->getIgnoredColumns()[$column])) {
                     continue;
+                }
+                if (!isset($storageEntity[$column])) {
+                    throw new \PHPUnit_Framework_AssertionFailedError("{$entityName}[$column] with value = $value, ID = $id not found in storage");
                 }
 
                 if (is_string($storageEntity[$column])) {


### PR DESCRIPTION
Resolves #909.

`DbAsserter.php` now compares each column from database with value returned from `Storage`. Before this change if column from database was not found in storage it was skipped from any other processing. Implementing this issue has also 2 side effects : 
- ignoring of option `theme_switched`
- `false` values sent to *INSERT* or *UPDATE* query are now transformed to `""` (empty string)

Reviewers:

- [x] @JanVoracek 
- [x] @borekb 