### PR TITLE
Separate gulp task for Selenium

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -133,7 +133,7 @@ This is especially useful:
 2. If you want to **debug** some test
 3. If you want to run a **specific end2end test**, e.g., `PostsTest`.
 
-Just right-click on desired directory / class (`tests` for all, `tests/Unit` for unit tests etc.) and choose *Run*. (For End2End tests with Selenium worker, you need to start the Selenium server manually first.)
+Just right-click on desired directory / class (`tests` for all, `tests/Unit` for unit tests etc.) and choose *Run*. (For End2End tests with Selenium worker, you need to start the Selenium server first. You can use `gulp start-selenium`.)
 
 
 ### Logging

--- a/plugins/versionpress/tests/gulpfile.js
+++ b/plugins/versionpress/tests/gulpfile.js
@@ -20,6 +20,11 @@ gulp.task('default', function () {
         }
 
         console.log('');
+        console.log(chalk.bold('Commands:'));
+        console.log('gulp run-tests');
+        console.log('gulp start-selenium');
+        console.log('');
+        console.log(chalk.bold.underline('gulp run-tests'));
         console.log(chalk.cyan('Usage:') + ' ' + chalk.bold('gulp run-tests [--force-setup[=before-suite|before-class]]'));
         console.log('');
         console.log(chalk.cyan('Options:'));


### PR DESCRIPTION
Resolves #936.

I split the original `run-tests` into two tasks – one for starting Selenium server, the second one for running the tests.

Reviewers:
- [x] @borekb 
- [x] @octopuss 