### PR TITLE
Deactivating VP plugin before full activation causes warnings

### DIFF
--- a/plugins/versionpress/src/Git/MergeDriverInstaller.php
+++ b/plugins/versionpress/src/Git/MergeDriverInstaller.php
@@ -133,11 +133,13 @@ class MergeDriverInstaller {
             file_put_contents($gitattributesPath, $gitAttributes);
         }
 
-        $gitConfig = file_get_contents($gitconfigPath);
-        // https://regex101.com/r/eJ4rJ5/4
-        $mergeDriverRegex = "/(\\[merge \\\"vp\\-ini\\\"\\]\\r?\\n)([^\\[]*)/";
-        $gitConfig = preg_replace($mergeDriverRegex, '', $gitConfig, 1);
-        file_put_contents($gitconfigPath, $gitConfig);
+        if (file_exists($gitconfigPath)) {
+            $gitConfig = file_get_contents($gitconfigPath);
+            // https://regex101.com/r/eJ4rJ5/4
+            $mergeDriverRegex = "/(\\[merge \\\"vp\\-ini\\\"\\]\\r?\\n)([^\\[]*)/";
+            $gitConfig = preg_replace($mergeDriverRegex, '', $gitConfig, 1);
+            file_put_contents($gitconfigPath, $gitConfig);
+        }
     }
 
 }


### PR DESCRIPTION
Resolves #944.

The file `.git/config` may not exist if VersionPress wasn't fully activated. 

Reviewers:
- [x] @octopuss 