### PR TITLE
Uninstall merge driver is not part of deactivation commit

### DIFF
--- a/plugins/versionpress/src/ChangeInfos/VersionPressChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/VersionPressChangeInfo.php
@@ -88,6 +88,7 @@ class VersionPressChangeInfo extends TrackedChangeInfo {
                     array("type" => "path", "path" => VP_VPDB_DIR . "/*"),
                     array("type" => "path", "path" => ABSPATH . WPINC . "/wp-db.php"),
                     array("type" => "path", "path" => ABSPATH . WPINC . "/wp-db.php.original"),
+                    array("type" => "path", "path" => ABSPATH . "/.gitattributes"),
                 );
             default:
                 return array(array("type" => "path", "path" => "*"));

--- a/plugins/versionpress/src/Git/MergeDriverInstaller.php
+++ b/plugins/versionpress/src/Git/MergeDriverInstaller.php
@@ -137,8 +137,8 @@ class MergeDriverInstaller {
         if (file_exists($gitattributesPath)) {
             $gitAttributes = file_get_contents($gitattributesPath);
             $gitAttributes = str_replace($gitattributesContents, '', $gitAttributes);
-            if(trim($gitAttributes) === '') {
-                unlink ($gitattributesPath);
+            if (trim($gitAttributes) === '') {
+                unlink($gitattributesPath);
             } else {
                 file_put_contents($gitattributesPath, $gitAttributes);
 

--- a/plugins/versionpress/src/Git/MergeDriverInstaller.php
+++ b/plugins/versionpress/src/Git/MergeDriverInstaller.php
@@ -57,17 +57,17 @@ class MergeDriverInstaller {
         $gitattributesVariables = array(
             'vpdb-dir' => rtrim(ltrim(PathUtils::getRelativePath($rootDir, $vpdbDir), '.'), '/\\')
         );
-        $gitattributesContents = "\n" . StringUtils::fillTemplateString($gitattributesVariables, $gitattributesContents);
+        $gitattributesContents = StringUtils::fillTemplateString($gitattributesVariables, $gitattributesContents);
 
-        $appendFlag = null;
         if (is_file($gitattributesPath)) {
-            $appendFlag = FILE_APPEND;
-            if (strpos(file_get_contents($gitattributesPath), 'merge=vp-ini') !== false) {
+            $gitAttributesFileContents = file_get_contents($gitattributesPath);
+            if (strpos($gitAttributesFileContents, $gitattributesContents) !== false) {
                 return;
             }
+            $gitattributesContents = $gitattributesContents . $gitAttributesFileContents;
         }
 
-        file_put_contents($gitattributesPath, $gitattributesContents, $appendFlag);
+        file_put_contents($gitattributesPath, $gitattributesContents);
     }
 
 
@@ -123,14 +123,26 @@ class MergeDriverInstaller {
      *
      * @param string $rootDir
      */
-    public static function uninstallMergeDriver($rootDir) {
+    public static function uninstallMergeDriver($rootDir, $pluginDir, $vpdbDir) {
         $gitconfigPath = $rootDir . '/.git/config';
         $gitattributesPath = $rootDir . '/.gitattributes';
 
+        $gitattributesContents = file_get_contents($pluginDir . '/src/Initialization/.gitattributes.tpl');
+
+        $gitattributesVariables = array(
+            'vpdb-dir' => rtrim(ltrim(PathUtils::getRelativePath($rootDir, $vpdbDir), '.'), '/\\')
+        );
+        $gitattributesContents = StringUtils::fillTemplateString($gitattributesVariables, $gitattributesContents);
+
         if (file_exists($gitattributesPath)) {
             $gitAttributes = file_get_contents($gitattributesPath);
-            $gitAttributes = preg_replace('/(.*)merge=vp-ini/', '', $gitAttributes);
-            file_put_contents($gitattributesPath, $gitAttributes);
+            $gitAttributes = str_replace($gitattributesContents, '', $gitAttributes);
+            if(trim($gitAttributes) === '') {
+                unlink ($gitattributesPath);
+            } else {
+                file_put_contents($gitattributesPath, $gitAttributes);
+
+            }
         }
 
         $gitConfig = file_get_contents($gitconfigPath);

--- a/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
+++ b/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
@@ -51,9 +51,20 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
      */
     public function mergeDriverUninstalledCorrectly() {
         $this->installMergeDriver('auto');
-        MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir);
+        file_put_contents(self::$repositoryDir . "/.gitattributes", "*.txt text", FILE_APPEND);
+        MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir, __DIR__ . '/../..', self::$repositoryDir);
         $this->assertNotContains('vp-ini', file_get_contents(self::$repositoryDir . "/.git/config"));
         $this->assertNotContains('merge=vp-ini', file_get_contents(self::$repositoryDir . "/.gitattributes"));
+    }
+
+    /**
+     * @test
+     */
+    public function gitAttributesRemovedCorrectlyAfterUninstall() {
+        $this->installMergeDriver('auto');
+        MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir, __DIR__ . '/../..', self::$repositoryDir);
+        $this->assertNotContains('vp-ini', file_get_contents(self::$repositoryDir . "/.git/config"));
+        $this->assertFileNotExists(self::$repositoryDir . "/.gitattributes");
     }
 
     /**

--- a/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
+++ b/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
@@ -85,7 +85,7 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
         $gitattributesContents = file_get_contents(__DIR__ . '/../../src/Initialization/.gitattributes.tpl');
         $gitConfigContents = "[merge \"vp-ini\"]";
         $gitattributesVariables = array(
-            'vpdb-dir' => rtrim(ltrim(PathUtils::getRelativePath(self::$repositoryDir, self::$repositoryDir), '.'), '/\\')
+            'vpdb-dir' => self::$repositoryDir
         );
         $gitattributesContents = StringUtils::fillTemplateString($gitattributesVariables, $gitattributesContents);
         file_put_contents(self::$repositoryDir . "/.gitattributes", $gitattributesContents);

--- a/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
+++ b/plugins/versionpress/tests/GitRepositoryTests/MergeDriverTest.php
@@ -4,6 +4,7 @@ namespace VersionPress\Tests\GitRepositoryTests;
 use VersionPress\Git\MergeDriverInstaller;
 use VersionPress\Tests\Utils\MergeAsserter;
 use VersionPress\Tests\Utils\MergeDriverTestUtils;
+use VersionPress\Utils\PathUtils;
 use VersionPress\Utils\StringUtils;
 
 class MergeDriverTest extends \PHPUnit_Framework_TestCase {
@@ -51,10 +52,47 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
      */
     public function mergeDriverUninstalledCorrectly() {
         $this->installMergeDriver('auto');
-        file_put_contents(self::$repositoryDir . "/.gitattributes", "*.txt text", FILE_APPEND);
+        file_put_contents(self::$repositoryDir . "/.gitattributes", "*.txt text");
         MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir, __DIR__ . '/../..', self::$repositoryDir);
         $this->assertNotContains('vp-ini', file_get_contents(self::$repositoryDir . "/.git/config"));
         $this->assertNotContains('merge=vp-ini', file_get_contents(self::$repositoryDir . "/.gitattributes"));
+    }
+
+    /**
+     * @test
+     */
+    public function gitAttributesRemovedWhenEmpty() {
+        $this->installMergeDriver('auto');
+        MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir, __DIR__ . '/../..', self::$repositoryDir);
+        $this->assertFileNotExists(self::$repositoryDir . "/.gitattributes");
+    }
+
+    /**
+     * @test
+     */
+    public function gitAttributesIsSameAfterInstallAndUninstall() {
+        $gitAttributesContent = "*.txt text\n*.jpg binary";
+        file_put_contents(self::$repositoryDir . "/.gitattributes", $gitAttributesContent);
+        $this->installMergeDriver('auto');
+        MergeDriverInstaller::uninstallMergeDriver(self::$repositoryDir, __DIR__ . '/../..', self::$repositoryDir);
+        $this->assertEquals($gitAttributesContent, file_get_contents(self::$repositoryDir . "/.gitattributes"));
+    }
+
+    /**
+     * @test
+     */
+    public function mergeDriverIsNotAddedWhenPresent() {
+        $gitattributesContents = file_get_contents(__DIR__ . '/../../src/Initialization/.gitattributes.tpl');
+        $gitConfigContents = "[merge \"vp-ini\"]";
+        $gitattributesVariables = array(
+            'vpdb-dir' => rtrim(ltrim(PathUtils::getRelativePath(self::$repositoryDir, self::$repositoryDir), '.'), '/\\')
+        );
+        $gitattributesContents = StringUtils::fillTemplateString($gitattributesVariables, $gitattributesContents);
+        file_put_contents(self::$repositoryDir . "/.gitattributes", $gitattributesContents);
+        file_put_contents(self::$repositoryDir . "/.git/config", $gitConfigContents);
+        $this->installMergeDriver('auto');
+        $this->assertEquals($gitConfigContents, file_get_contents(self::$repositoryDir . "/.git/config"));
+        $this->assertEquals($gitattributesContents, file_get_contents(self::$repositoryDir . "/.gitattributes"));
     }
 
     /**
@@ -86,7 +124,7 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
 
         MergeDriverTestUtils::writeIniFile('file.ini', '2011-11-11 11:11:11');
         MergeDriverTestUtils::commit('Initial commit to common ancestor');
-        
+
         MergeDriverTestUtils::runGitCommand('git checkout -b test-branch');
 
         MergeDriverTestUtils::writeIniFile('file.ini', '2012-12-12 12:12:12');
@@ -173,7 +211,6 @@ class MergeDriverTest extends \PHPUnit_Framework_TestCase {
 
         MergeAsserter::assertCleanMerge('git merge test-branch');
     }
-
 
 
 }

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -649,7 +649,7 @@ function vp_admin_post_confirm_deactivation() {
     $wpdbMirrorBridge = $versionPressContainer->resolve(VersionPressServices::WPDB_MIRROR_BRIDGE);
     $wpdbMirrorBridge->disable();
 
-    MergeDriverInstaller::uninstallMergeDriver(VP_PROJECT_ROOT);
+    MergeDriverInstaller::uninstallMergeDriver(VP_PROJECT_ROOT, VERSIONPRESS_PLUGIN_DIR, VP_VPDB_DIR);
     
     /** @var \VersionPress\Database\Database $database */
     $database = $versionPressContainer->resolve(VersionPressServices::DATABASE);

--- a/plugins/versionpress/versionpress.php
+++ b/plugins/versionpress/versionpress.php
@@ -28,7 +28,6 @@ use VersionPress\Initialization\VersionPressOptions;
 use VersionPress\Initialization\WpdbReplacer;
 use VersionPress\Storages\Mirror;
 use VersionPress\Storages\StorageFactory;
-use VersionPress\Utils\BugReporter;
 use VersionPress\Utils\CompatibilityChecker;
 use VersionPress\Utils\CompatibilityResult;
 use VersionPress\Utils\FileSystem;


### PR DESCRIPTION
Resolves #920.

- `.gitattributes` file is deleted when empty
- empty lines are not added to(left in) file
- if user change merge driver statement in `.gitattributes` to custom value, it is not replaced but new line with correct value is added.

Reviewers:

- [x] @JanVoracek 

Thank you