### PR TITLE
Set environment name before activation

### DIFF
--- a/plugins/versionpress/admin/inc/activate.php
+++ b/plugins/versionpress/admin/inc/activate.php
@@ -8,18 +8,24 @@ use VersionPress\VersionPress;
 
 /**
  * Function executed from VersionPress\Initialization\Initializer that is given the progress message, decides
- * whether it is suitable for output and if so, calls `show_message()` (WP function).
+ * whether it is suitable for output and if so, calls WP's `show_message()` function. Displaying can be forced
+ * using the $forceDisplay parameter.
  *
  * @param string $progressMessage
+ * @param bool $forceDisplay If true, displays the message regardless of its presence in InitializerStates enum
  */
-function _vp_show_progress_message($progressMessage) {
+function _vp_show_progress_message($progressMessage, $forceDisplay = false) {
 
     // We currently only output messages that are defined in VersionPress\Initialization\InitializerStates
-    // which captures the main progress points without too many details
+    // which captures the main progress points without too many details. Or if $forceDisplay is true.
+    $shouldDisplayMessage = $forceDisplay;
+    if (!$shouldDisplayMessage) {
+        $initializerStatesReflection = new ReflectionClass('VersionPress\Initialization\InitializerStates');
+        $progressConstantValues = array_values($initializerStatesReflection->getConstants());
+        $shouldDisplayMessage = in_array($progressMessage, $progressConstantValues);
+    }
 
-    $initializerStatesReflection = new ReflectionClass('VersionPress\Initialization\InitializerStates');
-    $progressConstantValues = array_values($initializerStatesReflection->getConstants());
-    if (in_array($progressMessage, $progressConstantValues)) {
+    if ($shouldDisplayMessage) {
         /** @noinspection PhpParamsInspection */
         /** @noinspection PhpInternalEntityUsedInspection */
         show_message($progressMessage);
@@ -78,14 +84,29 @@ function _vp_show_progress_message($progressMessage) {
 
         <div class="initialization-progress">
             <?php
-            global $versionPressContainer;
 
-            /**
-             * @var Initializer $initializer
-             */
+            // Set the env name in wp-config.php
+            if (isset($_GET['envname']) && \VersionPress\Utils\WorkflowUtils::isCloneNameValid($_GET['envname'])) {
+                $envName = $_GET['envname'];
+            } else {
+                $envName = 'default';
+            }
+
+            $wpConfigPath = \VersionPress\Utils\WordPressMissingFunctions::getWpConfigPath();
+            $wpConfigEditor = new \VersionPress\Utils\WpConfigEditor($wpConfigPath, false);
+            $wpConfigEditor->updateConfigConstant('VP_ENVIRONMENT', $envName);
+
+            _vp_show_progress_message("Environment set to '$envName'", true);
+
+
+            // Do the initialization
+            global $versionPressContainer;
+            /** @var Initializer $initializer */
             $initializer = $versionPressContainer->resolve(VersionPressServices::INITIALIZER);
             $initializer->onProgressChanged[] = '_vp_show_progress_message';
-            $initializer->initializeVersionPress(); // This is a long-running operation
+
+            $initializer->initializeVersionPress();
+
 
             $successfullyInitialized = VersionPress::isActive();
 

--- a/plugins/versionpress/admin/inc/activationPanel.php
+++ b/plugins/versionpress/admin/inc/activationPanel.php
@@ -7,13 +7,6 @@ use VersionPress\Utils\RequirementsChecker;
 
 ?>
 
-<style>
-    h4 {
-        margin-top: 30px;
-        margin-bottom: 10px;
-    }
-</style>
-
 <script>
 
 jQuery(document).ready(function($) {
@@ -112,7 +105,7 @@ jQuery(document).ready(function($) {
                         E.g., <code>production</code>, <code>dev</code> or <code>my-machine</code>. This will help you identify this environment later.
 
                         <div style="margin-top: 10px;">
-                            <label for="envname"><?php _e('Environment name:') ?></label>
+                            <label for="envname">Environment name:</label>
                             <input name="envname" type="text" id="envname" value="default" />
 
                         </div>

--- a/plugins/versionpress/admin/inc/activationPanel.php
+++ b/plugins/versionpress/admin/inc/activationPanel.php
@@ -7,6 +7,31 @@ use VersionPress\Utils\RequirementsChecker;
 
 ?>
 
+<style>
+    h4 {
+        margin-top: 30px;
+        margin-bottom: 10px;
+    }
+</style>
+
+<script>
+
+jQuery(document).ready(function($) {
+    $('#activate-versionpress-btn').click(function (e) {
+        var envname = $('#envname').val();
+
+        // Quick and dirty validation; the canonical regexp is in WorkflowUtils::isCloneNameValid().
+        if (!/^[a-zA-Z0-9-_]+$/.test(envname)) {
+            alert('Please use letters, numbers, \'-\' and \'_\' for environment name only');
+            e.preventDefault();
+        }
+
+        $(this).attr('href', this.href + '&envname=' + encodeURIComponent(envname));
+    });
+});
+
+</script>
+
 <div class="welcome-panel vp-activation-panel">
 
     <div class="welcome-panel-content">
@@ -78,6 +103,25 @@ use VersionPress\Utils\RequirementsChecker;
                         <strong>Have a backup</strong>. Seriously.
                     </li>
                 </ul>
+
+                <h4>Name your environment</h4>
+
+                <ul>
+                    <li>
+                        <span class="dashicons dashicons-info icon" style="color: #5b9dd9; font-size: 1.2em; left: -28px;"></span>
+                        E.g., <code>production</code>, <code>dev</code> or <code>my-machine</code>. This will help you identify this environment later.
+
+                        <div style="margin-top: 10px;">
+                            <label for="envname"><?php _e('Environment name:') ?></label>
+                            <input name="envname" type="text" id="envname" value="default" />
+
+                        </div>
+
+                    </li>
+                </ul>
+
+
+
 
 
             </div>

--- a/plugins/versionpress/admin/public/css/style.css
+++ b/plugins/versionpress/admin/public/css/style.css
@@ -23,6 +23,11 @@
     width: 48%;
 }
 
+.vp-activation-panel h4 {
+    margin-top: 30px;
+    margin-bottom: 10px;
+}
+
 /*------------------------------
  * Admin pages
  *------------------------------*/

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -23,6 +23,7 @@ use VersionPress\Synchronizers\SynchronizationProcess;
 use VersionPress\Utils\FileSystem;
 use VersionPress\Utils\PathUtils;
 use VersionPress\Utils\RequirementsChecker;
+use VersionPress\Utils\WorkflowUtils;
 use VersionPress\VersionPress;
 use WP_CLI;
 use WP_CLI_Command;
@@ -378,7 +379,7 @@ class VPCommand extends WP_CLI_Command {
 
         $name = $assoc_args['name'];
 
-        if (preg_match('/[^a-zA-Z0-9-_]/', $name)) {
+        if (!WorkflowUtils::isCloneNameValid($name)) {
             WP_CLI::error("Clone name '$name' is not valid. It can only contain letters, numbers, hyphens and underscores.");
         }
 

--- a/plugins/versionpress/src/Utils/WorkflowUtils.php
+++ b/plugins/versionpress/src/Utils/WorkflowUtils.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace VersionPress\Utils;
+
+/**
+ * Assorted helper functions for workflow functionality (cloning, merging, ...)
+ * for now. This will probably be refactored into its own namespace and better
+ * structured classes one day.
+ */
+class WorkflowUtils {
+
+    public static function isCloneNameValid($cloneName) {
+        return preg_match('/^[a-zA-Z0-9-_]+$/', $cloneName) === 1;
+    }
+
+}

--- a/plugins/versionpress/tests/Workflow/WorkflowUtilsTest.php
+++ b/plugins/versionpress/tests/Workflow/WorkflowUtilsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace VersionPress\Tests\Workflow;
+
+
+use VersionPress\Utils\WorkflowUtils;
+
+class WorkflowUtilsTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * @test
+     */
+    public function isCloneNameValidReturnsTrueForValidNames() {
+        $this->assertTrue(WorkflowUtils::isCloneNameValid('a'));
+        $this->assertTrue(WorkflowUtils::isCloneNameValid('_'));
+        $this->assertTrue(WorkflowUtils::isCloneNameValid('-'));
+        $this->assertTrue(WorkflowUtils::isCloneNameValid('1'));
+        $this->assertTrue(WorkflowUtils::isCloneNameValid('abc123_-'));
+    }
+
+    /**
+     * @test
+     */
+    public function isCloneNameValidReturnsFalseForInvalidNames() {
+        $this->assertFalse(WorkflowUtils::isCloneNameValid('**'));
+        $this->assertFalse(WorkflowUtils::isCloneNameValid(''));
+        $this->assertFalse(WorkflowUtils::isCloneNameValid('abc**'));
+    }
+}


### PR DESCRIPTION
Resolves #951.

There's a new piece of UI on the pre-activation screen:

![name-environment-pre-activation](https://cloud.githubusercontent.com/assets/101152/14668426/7d7f7678-06e4-11e6-94d9-35bf3f162785.png)

The entered environment name is validated slightly in JavaScript (quick alert, nothing too fancy) and then on the server-side. If server-side validation fails, `default` is used as an env name (see #847).

Reviewers:

- [x] @JanVoracek 
- [x] @octopuss 