### PR TITLE
Unsaved post create draft

### DIFF
--- a/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
@@ -121,7 +121,6 @@ abstract class PostTypeTestSeleniumWorker extends SeleniumWorker implements IPos
         $this->closeWindow();
         $this->window('');
         $this->url($this->getPostTypeScreenUrl());
-        $this->acceptAlert();
     }
 
     public function prepare_setFeaturedImageForUnsavedPost() {


### PR DESCRIPTION
Resolves #959.

Removed alert seem to not be present in selenium tests, so I've removed this test step.

Reviewers:

- [x] @JanVoracek 
