### PR TITLE
Better implementation of `makeDraftFromUnsavedPost()`

### DIFF
--- a/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
@@ -152,8 +152,8 @@ abstract class PostTypeTestSeleniumWorker extends SeleniumWorker implements IPos
 
     public function makeDraftFromUnsavedPost() {
         $this->byCssSelector('form#post input#title')->value('Test ' . $this->getPostType() . ' with featured image');
-        $this->byCssSelector('button#content-tmce')->click(); // set focus somewhere outside the title
-        sleep(1);
+        $this->keys(\PHPUnit_Extensions_Selenium2TestCase_Keys::TAB);
+        $this->waitForElement('#sample-permalink');
         $this->waitForAjax();
         $this->url($this->getPostTypeScreenUrl());
         $this->acceptAlert();


### PR DESCRIPTION
Done when working on #957 but does not really fix anything. The issue can be closed manually.

The new implementation does not depend on `sleep()`.

Reviewers:

- [x] @JanVoracek 
- [x] @octopuss 
