### PR TITLE
Default environment renamed to `default`

### DIFF
--- a/plugins/versionpress/src/VersionPress.php
+++ b/plugins/versionpress/src/VersionPress.php
@@ -25,7 +25,7 @@ class VersionPress
      */
     public static function getEnvironment()
     {
-        return defined('VP_ENVIRONMENT') ? VP_ENVIRONMENT : 'master';
+        return defined('VP_ENVIRONMENT') ? VP_ENVIRONMENT : 'default';
     }
 
     /**


### PR DESCRIPTION
Resolves #847.

Reviewers:
- [x] @octopuss 
