### PR TITLE
Undo of manually changed file deletes options

### DIFF
--- a/plugins/versionpress/src/Git/GitRepository.php
+++ b/plugins/versionpress/src/Git/GitRepository.php
@@ -26,12 +26,12 @@ class GitRepository
      */
     public function __construct(
         $workingDirectoryRoot,
-        $tempDirectory = ".",
+        $tempDirectory = null,
         $commitMessagePrefix = "[VP] ",
         $gitBinary = "git"
     ) {
         $this->workingDirectoryRoot = $workingDirectoryRoot;
-        $this->tempDirectory = $tempDirectory;
+        $this->tempDirectory = $tempDirectory ?: __DIR__;
         $this->commitMessagePrefix = $commitMessagePrefix;
         $this->gitBinary = $gitBinary;
     }

--- a/plugins/versionpress/src/Synchronizers/OptionsSynchronizer.php
+++ b/plugins/versionpress/src/Synchronizers/OptionsSynchronizer.php
@@ -58,6 +58,10 @@ class OptionsSynchronizer implements Synchronizer
 
     public function synchronize($task, $entitiesToSynchronize = null)
     {
+        if (is_array($entitiesToSynchronize) && count($entitiesToSynchronize) === 0) {
+            return [];
+        }
+
         $this->maybeInit($entitiesToSynchronize);
         $options = $this->options;
 

--- a/plugins/versionpress/tests/End2End/Revert/IRevertTestWorker.php
+++ b/plugins/versionpress/tests/End2End/Revert/IRevertTestWorker.php
@@ -48,4 +48,8 @@ interface IRevertTestWorker extends ITestWorker
     public function prepare_undoMultipleCommitsThatCannotBeReverted();
 
     public function undoMultipleCommitsThatCannotBeReverted();
+
+    public function prepare_undoNonDbChange();
+
+    public function undoNonDbChange();
 }

--- a/plugins/versionpress/tests/End2End/Revert/RevertTest.php
+++ b/plugins/versionpress/tests/End2End/Revert/RevertTest.php
@@ -258,4 +258,24 @@ class RevertTest extends End2EndTestCase
         $commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
+
+    /**
+     * @test
+     * @testdox Non-DB change doesn't break the database
+     */
+    public function undoOfNonDbChangeDoesntBreakDatabase()
+    {
+        $changes = self::$worker->prepare_undoNonDbChange();
+
+        $commitAsserter = new CommitAsserter($this->gitRepository);
+
+        self::$worker->undoNonDbChange();
+
+        $commitAsserter->assertNumCommits(1);
+        $commitAsserter->assertCommitAction('versionpress/undo');
+        $commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $commitAsserter->assertCommitPaths($changes);
+        $commitAsserter->assertCleanWorkingDirectory();
+        DBAsserter::assertFilesEqualDatabase();
+    }
 }

--- a/plugins/versionpress/tests/End2End/Revert/RevertTestWpCliWorker.php
+++ b/plugins/versionpress/tests/End2End/Revert/RevertTestWpCliWorker.php
@@ -184,6 +184,20 @@ class RevertTestWpCliWorker extends WpCliWorker implements IRevertTestWorker
         } // Intentionally empty catch. Violated referetial integrity throws an exception.
     }
 
+    public function prepare_undoNonDbChange()
+    {
+        $themeFile = 'wp-content/themes/twentyfifteen/header.php';
+        file_put_contents($this->testConfig->testSite->path . '/' . $themeFile, '');
+        $this->repository->stageAll($themeFile);
+        $this->repository->commit('Manual commit', 'John Tester', 'john.tester@example.com');
+        return [['M', $themeFile]];
+    }
+
+    public function undoNonDbChange()
+    {
+        $this->undoLastCommit();
+    }
+
     //---------------------
     // Helper methods
     //---------------------


### PR DESCRIPTION
Resolves #972.

There was some change in the parameter of `synchronize` method comming from `Reverter` (empty array instead of null).

I will add some test for this. 

Reviewers:
- [x] @octopuss 