### PR TITLE
Removal of @synopsis from PhpDocs

### DIFF
--- a/plugins/versionpress/src/Cli/vp-internal.php
+++ b/plugins/versionpress/src/Cli/vp-internal.php
@@ -32,10 +32,11 @@ class VPInternalCommand extends WP_CLI_Command
     /**
      * Finishes clone operation
      *
-     * --truncate-options
+     * ## OPTIONS
+     *
+     * [--truncate-options]
      * : By default, options table is not truncated. This flag changes the behavior.
      *
-     * @synopsis [--truncate-options]
      *
      * @subcommand finish-init-clone
      *
@@ -109,6 +110,8 @@ class VPInternalCommand extends WP_CLI_Command
     /**
      * Turns on or off the maintenance mode.
      *
+     * ## OPTIONS
+     *
      * <mode>
      * : Desired state of maintenance mode. Possible values are 'on' or 'off'.
      *
@@ -163,9 +166,12 @@ class VPInternalCommand extends WP_CLI_Command
     /**
      * Gets `id` of an entity from `vp_id` table
      *
+     * ## OPTIONS
+     *
+     * --vpid=<vpid>
+     *
      * @subcommand get-entity-id
      *
-     * @synopsis --vpid=<vpid>
      *
      */
     public function getEntityId($args = [], $assoc_args = [])
@@ -183,9 +189,14 @@ class VPInternalCommand extends WP_CLI_Command
     /**
      * Gets `vp_id` Guid of an entity from id and entity name
      *
+     * ## OPTIONS
+     *
+     * --id=<id>
+     * 
+     * --name=<name>
+     *
      * @subcommand get-entity-vpid
      *
-     * @synopsis --id=<id> --name=<name>
      *
      */
     public function getEntityVpid($args = [], $assoc_args = [])
@@ -209,18 +220,17 @@ class VPInternalCommand extends WP_CLI_Command
      * <value>
      * : Desired value. Supported types are: string, int, float and bool.
      *
-     * --plain
+     * [--plain]
      * : The value will be used as is - without type detection, quoting etc.
      *
-     * --variable
+     * [--variable]
      * : Will set a variable instead of constant. Useful for $table_prefix.
      *
-     * --common
+     * [--common]
      * : The constant / variable will be set in wp-config.common.php.
      *
      * @subcommand update-config
      *
-     * @synopsis <constant> <value> [--plain] [--variable] [--common]
      *
      * @when before_wp_load
      */

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -143,10 +143,9 @@ class VPCommand extends WP_CLI_Command
     /**
      * Starts tracking the site
      *
-     * --yes
+     * [--yes]
      * : Answer yes to the confirmation message.
      *
-     * @synopsis [--yes]
      */
     public function activate($args, $assoc_args)
     {
@@ -180,7 +179,7 @@ class VPCommand extends WP_CLI_Command
      * --siteurl=<url>
      * : The address of the restored site.
      *
-     * --yes
+     * [--yes]
      * : Answer yes to the confirmation message.
      *
      * ## DESCRIPTION
@@ -192,7 +191,6 @@ class VPCommand extends WP_CLI_Command
      *
      * If you just cloned the site from another repository, run `wp core config` first.
      *
-     * @synopsis --siteurl=<url> [--yes]
      *
      * @subcommand restore-site
      *
@@ -326,36 +324,36 @@ class VPCommand extends WP_CLI_Command
      * : Name of the clone. Used as a directory name, part of the DB prefix
      * and an argument to the pull & push commands later.
      *
-     * --siteurl=<url>
+     * [--siteurl=<url>]
      * : URL of the clone. By default, the original URL is searched for <cwd>
      * and replaced with the clone name.
      *
-     * --dbname=<dbname>
+     * [--dbname=<dbname>]
      * : Database name for the clone.
      *
-     * --dbuser=<dbuser>
+     * [--dbuser=<dbuser>]
      * : Database user for the clone.
      *
-     * --dbpass=<dbpass>
+     * [--dbpass=<dbpass>]
      * : Database user password for the clone.
      *
-     * --dbhost=<dbhost>
+     * [--dbhost=<dbhost>]
      * : Database host for the clone.
      *
-     * --dbprefix=<dbprefix>
+     * [--dbprefix=<dbprefix>]
      * : Database table prefix for the clone.
      *
-     * --dbcharset=<dbcharset>
+     * [--dbcharset=<dbcharset>]
      * : Database charset for the clone.
      *
-     * --dbcollate=<dbcollate>
+     * [--dbcollate=<dbcollate>]
      * : Database collation for the clone.
      *
-     * --force
+     * [--force]
      * : Forces cloning even if the target directory or DB tables exists.
      * Basically provides --yes to all warnings / confirmations.
      *
-     * --yes
+     * [--yes]
      * : Another way to force the clone
      *
      * ## EXAMPLES
@@ -373,9 +371,6 @@ class VPCommand extends WP_CLI_Command
      *    - Populates database tables with data
      *    - Makes the site accessible as 'http://localhost/myclone'
      *
-     * @synopsis --name=<name> [--siteurl=<url>] [--dbname=<dbname>] [--dbuser=<dbuser>] [--dbpass=<dbpass>]
-     *           [--dbhost=<dbhost>] [--dbprefix=<dbprefix>] [--dbcharset=<dbcharset>] [--dbcollate=<dbcollate>]
-     *           [--force] [--yes]
      *
      * @subcommand clone
      *
@@ -584,7 +579,7 @@ class VPCommand extends WP_CLI_Command
      *
      * ## OPTIONS
      *
-     * --from=<name|path|url>
+     * [--from=<name|path|url>]
      * : Where to pull from. Can be a clone name (specified previously during the
      * 'clone' command), a path or a URL. Defaults to 'origin' which is
      * automatically set in every clone by the 'clone' command.
@@ -603,7 +598,6 @@ class VPCommand extends WP_CLI_Command
      * This will pull the changes from 'origin' which was set to the parent site during the
      * 'clone' command.
      *
-     * @synopsis [--from=<name|path|url>]
      */
     public function pull($args = [], $assoc_args = [])
     {
@@ -729,7 +723,7 @@ class VPCommand extends WP_CLI_Command
      *
      * ## OPTIONS
      *
-     * --to=<name|path>
+     * [--to=<name|path>]
      * : Name of the clone or a path to it. Defaults to 'origin' which, in a clone,
      * points to its original site.
      *
@@ -745,7 +739,6 @@ class VPCommand extends WP_CLI_Command
      *     wp vp push --to=clonename
      *
      *
-     * @synopsis [--to=<name|path>]
      */
     public function push($args = [], $assoc_args = [])
     {
@@ -815,7 +808,6 @@ class VPCommand extends WP_CLI_Command
      *
      *     wp vp undo a34bc28,d12ef22
      *
-     * @synopsis <commit>
      *
      * @when before_wp_load
      */
@@ -896,7 +888,6 @@ class VPCommand extends WP_CLI_Command
      *
      *     wp vp rollback a34bc28
      *
-     * @synopsis <commit>
      *
      * @when before_wp_load
      *
@@ -988,7 +979,6 @@ class VPCommand extends WP_CLI_Command
      *
      *     wp vp update ../versionpress-4.0.zip
      *
-     * @synopsis <zip>
      *
      */
     public function update($args = [], $assoc_args = [])


### PR DESCRIPTION
Resolves #977.

Synopsis is now generated from `## OPTIONS` section in `wp-cli` command description.

Reviewers:

- [x] @JanVoracek 