### PR TITLE
`wp-config.common.php` commented

### DIFF
--- a/plugins/versionpress/src/Initialization/WpConfigSplitter.php
+++ b/plugins/versionpress/src/Initialization/WpConfigSplitter.php
@@ -28,7 +28,9 @@ class WpConfigSplitter
         self::ensureCommonConfigInclude($wpConfigPath, $commonConfigName);
 
         $configLines = file($wpConfigPath);
-        $commonConfigLines = is_file($commonConfigPath) ? file($commonConfigPath) : ["<?php\n"];
+        $commonConfigLines = is_file($commonConfigPath)
+            ? file($commonConfigPath)
+            : file(__DIR__ . '/wp-config.common.tpl.php');
 
         // https://regex101.com/r/zD3mJ4/2
         $constantsForRegex = join('|', self::$constantsForExtraction);

--- a/plugins/versionpress/src/Initialization/wp-config.common.tpl.php
+++ b/plugins/versionpress/src/Initialization/wp-config.common.tpl.php
@@ -1,0 +1,3 @@
+<?php
+// Configuration common to all VersionPress environments, included from `wp-config.php`.
+// Learn more at https://docs.versionpress.net/en/getting-started/configuration


### PR DESCRIPTION
Resolves #953.

`wp-config.common.php` now contains a comment that it has been added by VersionPress.

Reviewers:

- [x] @JanVoracek 
