### PR TITLE
The default database host changed

### DIFF
--- a/plugins/versionpress/tests/test-config.sample.yml
+++ b/plugins/versionpress/tests/test-config.sample.yml
@@ -33,11 +33,11 @@ sites:
     host: localhost
     db:
       # Database should be created. VersionPress does not create it
-      host: localhost
+      host: 127.0.0.1
       dbname: vp01
       user: vp01
       password: vp01
     wp-site:
       path: /Users/johdoe/Sites/vp01
       url: http://localhost/vp01
-      title: "VP Test @ localhost"
+      title: "VersionPress test @ localhost"


### PR DESCRIPTION
 The default database host name in sample file was `localhost`. On Unix, this has a special meaning. For connections to `localhost`, MySQL programs attempt to connect to the local server by using a Unix socket file. To ensure that the client makes a TCP/IP connection to the local server, we set host name value to `127.0.0.1`. I've also changed default test site title to be more descriptive.

Please review: 
- [x] @JanVoracek 

Thank you.