### PR TITLE
Test of YAML parsing fixed after default page title was renamed

### DIFF
--- a/plugins/versionpress/tests/Unit/TestConfigTest.php
+++ b/plugins/versionpress/tests/Unit/TestConfigTest.php
@@ -25,7 +25,7 @@ class TestConfigTest extends PHPUnit_Framework_TestCase
 
         // 'sites' section
         $this->assertArrayHasKey('vp01', $config->sites);
-        $this->assertEquals("VP Test @ localhost", $config->sites["vp01"]->title);
+        $this->assertEquals("localhost", $config->sites["vp01"]->host);
 
     }
 }


### PR DESCRIPTION
In commit 3fce4c6 the default title of the site was changed to be more user friendly. However, `TestConfigTest.php` was testing `yaml` parsing which fails on searching old title in parsed data.

Please review:

- [x] @JanVoracek 

Thank you.