### PR TITLE
Failing WpConfigSplitterTest

### DIFF
--- a/plugins/versionpress/tests/Unit/WpConfigSplitterTest.php
+++ b/plugins/versionpress/tests/Unit/WpConfigSplitterTest.php
@@ -4,8 +4,7 @@ namespace VersionPress\Tests\Unit;
 
 use VersionPress\Initialization\WpConfigSplitter;
 
-class WpConfigSplitterTest extends \PHPUnit_Framework_TestCase
-{
+class WpConfigSplitterTest extends \PHPUnit_Framework_TestCase {
     // @codingStandardsIgnoreStart
     private $originalConfig = <<<'DOC'
 <?php
@@ -117,7 +116,7 @@ DOC;
         $this->wpConfigPath = __DIR__ . '/wp-config.php';
         $this->commonConfigPath = dirname($this->wpConfigPath) . '/' . $this->commonConfigName;
         file_put_contents($this->wpConfigPath, $this->originalConfig);
-        $commonConfigTemplate = file_get_contents('../../src/Initialization/wp-config.common.tpl.php');
+        $commonConfigTemplate = file_get_contents(__DIR__ . '/../../src/Initialization/wp-config.common.tpl.php');
         $this->commonConfig = $commonConfigTemplate . $this->commonConfig;
         @unlink($this->commonConfigPath);
     }


### PR DESCRIPTION
Resolves #953 .

When the test was run in test suite, it failed because `wp-config.ocmmon.tpl.php` was not found. Sorry for reopening.

- [x] @JanVoracek 