### PR TITLE
Null values passed to serialization are replaced with <null>

### DIFF
--- a/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
+++ b/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
@@ -51,7 +51,7 @@ class IniSerializer
 
     private static $numberMarker = '<<<VP-Number>>>';
 
-    private static $nullMarker= '<null>';
+    private static $nullMarker = '<null>';
 
     /**
      * Serializes sectioned data array into an INI string

--- a/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
+++ b/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
@@ -51,6 +51,8 @@ class IniSerializer
 
     private static $numberMarker = '<<<VP-Number>>>';
 
+    private static $nullMarker= '<null>';
+
     /**
      * Serializes sectioned data array into an INI string
      *
@@ -294,7 +296,12 @@ class IniSerializer
      */
     private static function serializeKeyValuePair($key, $value)
     {
-        return $key . " = " . (is_string($value) ? '"' . self::escapeString($value) . '"' : $value);
+        if (is_null($value)) {
+            $value = self::$nullMarker;
+        } elseif (is_string($value)) {
+            $value = '"' . self::escapeString($value) . '"';
+        }
+        return $key . " = " . $value;
     }
 
     private static function sanitizeSectionsAndKeys_addPlaceholders($string) // @codingStandardsIgnoreLine
@@ -384,6 +391,8 @@ class IniSerializer
                 if (Strings::startsWith($value, self::$numberMarker)) {
                     // strip the marker and convert to number
                     $result[$key] = str_replace(self::$numberMarker, '', $value) + 0;
+                } elseif ($value === self::$nullMarker) {
+                    $result[$key] = null;
                 } else {
                     $result[$key] = self::unescapeString($value);
                 }

--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -285,7 +285,7 @@ class SerializedDataToIniConverter
             return self::convertObjectToSerializedString($type, $relatedLines);
         }
 
-        if ($type === 'null') {
+        if ($type === 'null' || $value === null) {
             return 'N;';
         }
 

--- a/plugins/versionpress/src/Utils/EntityUtils.php
+++ b/plugins/versionpress/src/Utils/EntityUtils.php
@@ -7,7 +7,8 @@ namespace VersionPress\Utils;
  * (for instance if the SQL update method is captured and only part of the entity data
  * is available). Here are some helper methods for such arrays.
  */
-class EntityUtils {
+class EntityUtils
+{
 
     /**
      * Used by storages to determine a diff between two entity data. Note that the data might

--- a/plugins/versionpress/src/Utils/EntityUtils.php
+++ b/plugins/versionpress/src/Utils/EntityUtils.php
@@ -7,8 +7,7 @@ namespace VersionPress\Utils;
  * (for instance if the SQL update method is captured and only part of the entity data
  * is available). Here are some helper methods for such arrays.
  */
-class EntityUtils
-{
+class EntityUtils {
 
     /**
      * Used by storages to determine a diff between two entity data. Note that the data might
@@ -33,7 +32,7 @@ class EntityUtils
     {
         $diff = [];
         foreach ($newEntityData as $key => $value) {
-            if (!isset($oldEntityData[$key]) || self::isChanged($oldEntityData[$key], $value)) {
+            if (!array_key_exists($key, $oldEntityData) || self::isChanged($oldEntityData[$key], $value)) {
                 $diff[$key] = $value;
             }
         }

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -1419,4 +1419,20 @@ INI
         $this->assertSame($ini, IniSerializer::serialize($data));
         $this->assertSame($data, IniSerializer::deserialize($ini));
     }
+
+    /**
+     * @test
+     */
+    public function nullValueSerializesCorrectly()
+    {
+        $data = ["Section" => ["data" => null]];
+        $ini = StringUtils::crlfize(<<<'INI'
+[Section]
+data = <null>
+
+INI
+        );
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+    }
 }

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -1435,4 +1435,20 @@ INI
         $this->assertSame($ini, IniSerializer::serialize($data));
         $this->assertSame($data, IniSerializer::deserialize($ini));
     }
+
+    /**
+     * @test
+     */
+    public function stringContaingNullPlaceholderIsDeserializedToOriginalString()
+    {
+        $data = ["Section" => ["data" => "<null>"]];
+        $ini = StringUtils::crlfize(<<<'INI'
+[Section]
+data = "<null>"
+
+INI
+        );
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+    }
 }


### PR DESCRIPTION
Resolves #1004 .

Null values are serialized as `<null>` and vice versa.

Reviewers:

- [x] @JanVoracek 