### PR TITLE
Failing clone with WP in its own directory

### DIFF
--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -401,10 +401,10 @@ class VPCommand extends WP_CLI_Command
             WP_CLI::error("Clone name '$name' is not valid. It can only contain letters, numbers, hyphens and underscores.");
         }
 
-        $currentWpPath = get_home_path();
+        $currentWpPath = realpath(VP_PROJECT_ROOT);
         $cloneDirName = $name;
         $clonePath = dirname($currentWpPath) . '/' . $cloneDirName;
-        $cloneVpPluginPath = $clonePath . '/' . str_replace(realpath(ABSPATH), '', realpath(VERSIONPRESS_PLUGIN_DIR));
+        $cloneVpPluginPath = $clonePath . '/' . str_replace($currentWpPath, '', realpath(VERSIONPRESS_PLUGIN_DIR));
 
         $cloneDbUser = isset($assoc_args['dbuser']) ? $assoc_args['dbuser'] : DB_USER;
         $cloneDbPassword = isset($assoc_args['dbpass']) ? $assoc_args['dbpass'] : DB_PASSWORD;
@@ -426,7 +426,7 @@ class VPCommand extends WP_CLI_Command
             $prefixChanged = true;
         }
 
-        $currentUrl = get_site_url();
+        $currentUrl = get_home_url();
         $suggestedUrl = $this->suggestCloneUrl($currentUrl, basename($currentWpPath), $cloneDirName);
 
         if (!$suggestedUrl && !isset($assoc_args['siteurl'])) {
@@ -512,8 +512,9 @@ class VPCommand extends WP_CLI_Command
         }
 
         // Copy & Update wp-config
-        $wpConfigFile = $clonePath . '/wp-config.php';
-        copy(\WP_CLI\Utils\locate_wp_config(), $wpConfigFile);
+        $wpConfigFile = \WP_CLI\Utils\locate_wp_config();
+        $cloneConfigFile = str_replace($currentWpPath, $clonePath, $wpConfigFile);
+        copy($wpConfigFile, $cloneConfigFile);
 
         $this->updateConfig(
             $clonePath,

--- a/plugins/versionpress/src/DI/DIContainer.php
+++ b/plugins/versionpress/src/DI/DIContainer.php
@@ -164,7 +164,7 @@ class DIContainer
         });
 
         $dic->register(VersionPressServices::URL_REPLACER, function () {
-            return new AbsoluteUrlReplacer(get_site_url());
+            return new AbsoluteUrlReplacer(get_home_url());
         });
 
         $dic->register(VersionPressServices::SHORTCODES_REPLACER, function () use ($dic) {

--- a/plugins/versionpress/src/Database/wordpress-schema.yml
+++ b/plugins/versionpress/src/Database/wordpress-schema.yml
@@ -113,7 +113,6 @@ option:
     - 'option_name: _site_transient_*'
     - 'option_name: cron'
     - 'option_name: home'
-    - 'option_name: siteurl'
     - 'option_name: db_upgraded'
     - 'option_name: rewrite_rules'
     - 'option_name: recently_edited'

--- a/plugins/versionpress/src/Initialization/Initializer.php
+++ b/plugins/versionpress/src/Initialization/Initializer.php
@@ -536,13 +536,14 @@ class Initializer
     {
 
         $gitignorePath = VP_PROJECT_ROOT . '/.gitignore';
+        $projectRoot = realpath(VP_PROJECT_ROOT);
 
         $vpGitignore = file_get_contents(__DIR__ . '/.gitignore.tpl');
 
         $gitIgnoreVariables = [
-            'wp-content' => '/' . PathUtils::getRelativePath(VP_PROJECT_ROOT, WP_CONTENT_DIR),
-            'wp-plugins' => '/' . PathUtils::getRelativePath(VP_PROJECT_ROOT, WP_PLUGIN_DIR),
-            'abspath' => '/' . PathUtils::getRelativePath(VP_PROJECT_ROOT, ABSPATH),
+            'wp-content' => '/' . PathUtils::getRelativePath($projectRoot, realpath(WP_CONTENT_DIR)),
+            'wp-plugins' => '/' . PathUtils::getRelativePath($projectRoot, realpath(WP_PLUGIN_DIR)),
+            'abspath' => '/' . PathUtils::getRelativePath($projectRoot, realpath(ABSPATH)),
         ];
 
         $vpGitignore = StringUtils::fillTemplateString($gitIgnoreVariables, $vpGitignore);


### PR DESCRIPTION
Resolves #1018, resolves #1013.

Fixed bugs related to cloning with WordPress in its own directory:
- Path detection in Initializer (causing wrong paths in `.gitignore`)
- Multiple usages of `get_site_url()` instead of `get_home_url()` (causing unreachable wp-admin)
- Wrong detection of path of `wp-config.php` on the clone (cloned site was using the same tables as original)
- VersionPress now tracks option `siteurl` (it is necessary to track it – it's the only information source about changed directory structure).

Reviewers:
- [x] @octopuss 