### PR TITLE
Happy blogging

### DIFF
--- a/plugins/versionpress/tests/Unit/WpConfigEditorTest.php
+++ b/plugins/versionpress/tests/Unit/WpConfigEditorTest.php
@@ -542,4 +542,110 @@ require_once(ABSPATH . \'wp-settings.php\');
 
         $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
     }
+
+    /**
+     * @test
+     */
+    public function editorWorksWithLocalizedWpConfig()
+    {
+        file_put_contents($this->commonConfigPath, '<?php
+// ** MySQL settings ** //
+/** The name of the database for WordPress */
+define(\'DB_NAME\', \'vp01\');
+
+$table_prefix = \'wp_\';
+
+
+
+/* C\'est tout, ne touchez pas à ce qui suit ! Bon blogging ! */
+
+/** Absolute path to the WordPress directory. */
+if ( !defined(\'ABSPATH\') )
+    define(\'ABSPATH\', dirname(__FILE__) . \'/\');
+
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . \'wp-settings.php\');
+');
+
+        $a = new WpConfigEditor($this->commonConfigPath, false);
+        $a->updateConfigConstant('TEST', 'value');
+
+        $expectedContent = '<?php
+// ** MySQL settings ** //
+/** The name of the database for WordPress */
+define(\'DB_NAME\', \'vp01\');
+
+$table_prefix = \'wp_\';
+
+
+
+define(\'TEST\', \'value\');
+/* C\'est tout, ne touchez pas à ce qui suit ! Bon blogging ! */
+
+/** Absolute path to the WordPress directory. */
+if ( !defined(\'ABSPATH\') )
+    define(\'ABSPATH\', dirname(__FILE__) . \'/\');
+
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . \'wp-settings.php\');
+';
+
+        $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
+    }
+
+    /**
+     * @test
+     */
+    public function editorWorksWithoutHappyBloggingComment()
+    {
+        file_put_contents($this->commonConfigPath, '<?php
+define(\'DB_NAME\', \'vp01\');
+$table_prefix = \'wp_\';
+
+if ( !defined(\'ABSPATH\') )
+    define(\'ABSPATH\', dirname(__FILE__) . \'/\');
+require_once(ABSPATH . \'wp-settings.php\');
+');
+
+        $a = new WpConfigEditor($this->commonConfigPath, false);
+        $a->updateConfigConstant('TEST', 'value');
+
+        $expectedContent = '<?php
+define(\'DB_NAME\', \'vp01\');
+$table_prefix = \'wp_\';
+
+define(\'TEST\', \'value\');
+if ( !defined(\'ABSPATH\') )
+    define(\'ABSPATH\', dirname(__FILE__) . \'/\');
+require_once(ABSPATH . \'wp-settings.php\');
+';
+
+        $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
+    }
+
+    /**
+     * @test
+     */
+    public function editorWorksWithoutDefiningAbspath()
+    {
+        file_put_contents($this->commonConfigPath, '<?php
+define(\'DB_NAME\', \'vp01\');
+$table_prefix = \'wp_\';
+
+require_once(ABSPATH . \'wp-settings.php\');
+');
+
+        $a = new WpConfigEditor($this->commonConfigPath, false);
+        $a->updateConfigConstant('TEST', 'value');
+
+        $expectedContent = '<?php
+define(\'DB_NAME\', \'vp01\');
+$table_prefix = \'wp_\';
+
+define(\'TEST\', \'value\');
+require_once(ABSPATH . \'wp-settings.php\');
+';
+
+        $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
+    }
 }


### PR DESCRIPTION
Resolves #1010.

The algorithm now tries to find a one-line comment containing exclamation mark (*stop editing!*, *ne touchez pas à ce qui suit !*, *Schluss mit dem Bearbeiten!*, *Это всё, дальше не редактируем. Успехов!*). If there is no such comment it tries to find `if ( !defined('ABSPATH') )` or `require_once(ABSPATH . 'wp-settings.php');`.

Reviewers:
- [x] @octopuss 