### PR TITLE
Show diff for added and deleted empty text file

### DIFF
--- a/frontend/src/Commits/DiffPanel.react.tsx
+++ b/frontend/src/Commits/DiffPanel.react.tsx
@@ -105,8 +105,23 @@ export default class DiffPanel extends React.Component<DiffPanelProps, any> {
     return [left, right];
   }
 
-  private static formatChunks(chunks: any[]) {
+  private static formatInfoForPlainFileDiff(diff) {
+    let chunks = diff.chunks;
     let result = [];
+    
+    if(chunks.length === 0) {
+      let message;
+      if (diff.from === '/dev/null') {
+        message = 'Added empty file';
+      } else {
+        message = 'Removed empty file';
+      }
+
+      result.push(<div className='binary-file-info'>{message}</div>);
+      return result;
+    }
+
+
     let chunkTables = chunks.map((chunk, i) =>
         DiffPanel.createTableFromChunk(chunk, i)
     );
@@ -172,7 +187,7 @@ export default class DiffPanel extends React.Component<DiffPanelProps, any> {
           <div className='DiffPanel' key={i}>
             <h4 className='heading'>{(diff.from === '/dev/null' ? diff.to : diff.from).substr(2)}</h4>
             {diff.type === 'plain'
-              ? DiffPanel.formatChunks(diff.chunks)
+              ? DiffPanel.formatInfoForPlainFileDiff(diff)
               : DiffPanel.formatInfoForBinaryFileDiff(diff)
             }
           </div>

--- a/frontend/src/Commits/DiffPanel.react.tsx
+++ b/frontend/src/Commits/DiffPanel.react.tsx
@@ -109,7 +109,7 @@ export default class DiffPanel extends React.Component<DiffPanelProps, any> {
     let chunks = diff.chunks;
     let result = [];
     
-    if(chunks.length === 0) {
+    if (chunks.length === 0) {
       let message;
       if (diff.from === '/dev/null') {
         message = 'Added empty file';

--- a/frontend/src/common/DiffParser.ts
+++ b/frontend/src/common/DiffParser.ts
@@ -11,7 +11,7 @@ export default class DiffParser {
     for (let i = 0; i < lines.length; i++) {
       let line = lines[i];
       let nextLine = lines[i + 1];
-      let afterNextLine = lines [i + 2]
+      let afterNextLine = lines [i + 2];
       let lineMatch = line.match(/^---\s(\S+)/);
       let nextLineMatch = nextLine ? nextLine.match(/^\+\+\+\s(\S+)/) : null;
       let afterNextLineMatch = afterNextLine ? afterNextLine.match(/^(diff --git)/) : true;
@@ -27,7 +27,7 @@ export default class DiffParser {
         i++; // Skip the +++ line
 
       } else if (line.match(/^(new|deleted) file mode .*/) && afterNextLineMatch) { // Empty files
-        let addedFileMatch = lines[i-1].match(/^diff --git (.*) (.*)/);
+        let addedFileMatch = lines[i - 1].match(/^diff --git (.*) (.*)/);
         let addDeleteMatch = line.match(/^(new|deleted) file mode .*/);
         addDeleteMatch[1] === 'new' ? addedFileMatch[1] = '/dev/null' : addedFileMatch[2] = '/dev/null';
         diffs.push({from: addedFileMatch[1], to: addedFileMatch[2], chunks: [], type: 'plain'});


### PR DESCRIPTION
Resolves #1014.

Diff is now displayed also for empty text files

<img width="1240" alt="screen shot 2016-05-02 at 1 48 00 pm" src="https://cloud.githubusercontent.com/assets/2697437/14953883/fc7ff942-106d-11e6-9037-5158d5ffb715.png">

Reviewers:

- [x] @JanVoracek 
- [x] @vasek17 