### PR TITLE
Remove VP constants on deactivation

### DIFF
--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -659,11 +659,6 @@ function vp_admin_post_confirm_deactivation()
         FileSystem::remove(VERSIONPRESS_ACTIVATION_FILE);
     }
 
-    $wpConfigPath = \VersionPress\Utils\WordPressMissingFunctions::getWpConfigPath();
-    \VersionPress\Utils\WpConfigEditor::removeVersionPressConstants([
-        $wpConfigPath,
-        dirname($wpConfigPath . '/' . WpConfigSplitter::COMMON_CONFIG_NAME),
-    ]);
     global $versionPressContainer;
     /** @var Committer $committer */
     $committer = $versionPressContainer->resolve(VersionPressServices::COMMITTER);

--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -659,6 +659,11 @@ function vp_admin_post_confirm_deactivation()
         FileSystem::remove(VERSIONPRESS_ACTIVATION_FILE);
     }
 
+    $wpConfigPath = \VersionPress\Utils\WordPressMissingFunctions::getWpConfigPath();
+    \VersionPress\Utils\WpConfigEditor::removeVersionPressConstants([
+        $wpConfigPath,
+        WpConfigSplitter::COMMON_CONFIG_NAME,
+    ]);
     global $versionPressContainer;
     /** @var Committer $committer */
     $committer = $versionPressContainer->resolve(VersionPressServices::COMMITTER);

--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -662,7 +662,7 @@ function vp_admin_post_confirm_deactivation()
     $wpConfigPath = \VersionPress\Utils\WordPressMissingFunctions::getWpConfigPath();
     \VersionPress\Utils\WpConfigEditor::removeVersionPressConstants([
         $wpConfigPath,
-        WpConfigSplitter::COMMON_CONFIG_NAME,
+        dirname($wpConfigPath . '/' . WpConfigSplitter::COMMON_CONFIG_NAME),
     ]);
     global $versionPressContainer;
     /** @var Committer $committer */

--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -13,6 +13,13 @@ class WpConfigEditor
     private $wpConfigPath;
     private $isCommonConfig;
 
+    private static $vpPublicConstants = [
+        'VP_VPDB_DIR',
+        'VP_PROJECT_ROOT',
+        'VP_ENVIRONMENT',
+        'VP_GIT_BINARY',
+    ];
+
     public function __construct($wpConfigPath, $isCommonConfig)
     {
         $this->wpConfigPath = $wpConfigPath;
@@ -38,16 +45,16 @@ class WpConfigEditor
     }
 
     /**
-     * Removes constants starting with 'VP_' from config files.
+     * Removes VersionPress public constants from config files.
      * @param array $configFiles List of config file paths from which constants should be removed.
      */
     public static function removeVersionPressConstants($configFiles)
     {
         foreach ($configFiles as $configFile) {
-            //https://regex101.com/r/iG7bE7/2
-            $constantRegex = "/^(\\s*define\\s*\\(\\s*['\"](VP)_.*['\"]\\s*,\\s*).*(\\s*\\)\\s*;\\s*)$/m";
+            $constantsForRegex = join('|', self::$vpPublicConstants);
+            $defineRegexPattern = "/(define\\s*\\(\\s*['\"]($constantsForRegex)['\"]\\s*,.*\\)\\s*;)/m";
             $wpConfigContent = file_get_contents($configFile);
-            file_put_contents($configFile, preg_replace($constantRegex, '', $wpConfigContent));
+            file_put_contents($configFile, preg_replace($defineRegexPattern, '', $wpConfigContent));
         }
     }
 

--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -52,6 +52,7 @@ class WpConfigEditor
     {
         foreach ($configFiles as $configFile) {
             $constantsForRegex = join('|', self::$vpPublicConstants);
+            // https://regex101.com/r/zD3mJ4/2
             $defineRegexPattern = "/(define\\s*\\(\\s*['\"]($constantsForRegex)['\"]\\s*,.*\\)\\s*;)/m";
             $wpConfigContent = file_get_contents($configFile);
             file_put_contents($configFile, preg_replace($defineRegexPattern, '', $wpConfigContent));

--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -38,6 +38,20 @@ class WpConfigEditor
     }
 
     /**
+     * Removes constants starting with 'VP_' from config files.
+     * @param array $configFiles List of config file paths from which constants should be removed.
+     */
+    public static function removeVersionPressConstants($configFiles)
+    {
+        foreach ($configFiles as $configFile) {
+            //https://regex101.com/r/iG7bE7/2
+            $constantRegex = "/^(\\s*define\\s*\\(\\s*['\"](VP)_.*['\"]\\s*,\\s*).*(\\s*\\)\\s*;\\s*)$/m";
+            $wpConfigContent = file_get_contents($configFile);
+            file_put_contents($configFile, preg_replace($constantRegex, '', $wpConfigContent));
+        }
+    }
+
+    /**
      * Sets value of a variable. It creates new one if it's missing.
      * By default it saves string in single quotes. See $usePlainValue.
      *

--- a/plugins/versionpress/uninstall.php
+++ b/plugins/versionpress/uninstall.php
@@ -12,6 +12,7 @@
 
 use VersionPress\DI\VersionPressServices;
 use VersionPress\Initialization\VersionPressOptions;
+use VersionPress\Initialization\WpConfigSplitter;
 use VersionPress\Utils\FileSystem;
 use VersionPress\Utils\SecurityUtils;
 use VersionPress\Utils\UninstallationUtil;
@@ -41,6 +42,12 @@ foreach ($queries as $query) {
 delete_option('vp_rest_api_plugin_version');
 
 FileSystem::remove(VP_VPDB_DIR);
+
+$wpConfigPath = \VersionPress\Utils\WordPressMissingFunctions::getWpConfigPath();
+\VersionPress\Utils\WpConfigEditor::removeVersionPressConstants([
+    $wpConfigPath,
+    dirname($wpConfigPath . '/' . WpConfigSplitter::COMMON_CONFIG_NAME),
+]);
 
 if (UninstallationUtil::uninstallationShouldRemoveGitRepo()) {
     $backupsDir = WP_CONTENT_DIR . '/vpbackups';


### PR DESCRIPTION
Resolves #1021 .

VersionPress constants are removed on uninstall. Also performed refactor of public constants (`VP_` prefixed)

Reviewers:

- [x] @JanVoracek 

Thank you