### PR TITLE
Fixed deserialization when serialized string is starting with HTML tag

### DIFF
--- a/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
+++ b/plugins/versionpress/src/Storages/Serialization/IniSerializer.php
@@ -165,9 +165,9 @@ class IniSerializer
         $deserialized = parse_ini_string($string, true, INI_SCANNER_RAW);
         $deserialized = self::restoreTypesOfValues($deserialized);
         $deserialized = self::sanitizeSectionsAndKeys_removePlaceholders($deserialized);
+        $deserialized = self::eolWorkaround_removePlaceholders($deserialized);
         $deserialized = self::restorePhpSerializedData($deserialized);
         $deserialized = self::expandArrays($deserialized);
-        $deserialized = self::eolWorkaround_removePlaceholders($deserialized);
         return $deserialized;
     }
 

--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -259,6 +259,12 @@ class SerializedDataToIniConverter
     {
         $type = null; // string or number
 
+        //@see IniSerializer::getReplacedEolString
+        $eolReplacement = [
+            "<<<[EOL-LF]>>>" => "\n",
+            "<<<[EOL-CR]>>>" => "\r",
+        ];
+
         // https://regex101.com/r/gJ1oF2/1
         if (preg_match('/^<(\*?[\w\d\\\\]+\*?)> ?(.*)/', $value, $matches)) {
             $type = $matches[1]; // detect type and value from eg. `<boolean> false`
@@ -302,7 +308,11 @@ class SerializedDataToIniConverter
             $value = preg_replace('/^"(.*)"$/', '$1', $value);
         }
 
-        return 's:' . strlen($value) . ':"' . $value . '";';
+        if ($type !== null && is_string($value)) {
+            $value = '<' . $type . '>' . $value;
+        }
+        $valueWithoutEolPlaceholders = str_replace(array_keys($eolReplacement), array_values($eolReplacement), $value);
+        return 's:' . strlen($valueWithoutEolPlaceholders) . ':"' . $value . '";';
     }
 
     /**

--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -259,12 +259,6 @@ class SerializedDataToIniConverter
     {
         $type = null; // string or number
 
-        //@see IniSerializer::getReplacedEolString
-        $eolReplacement = [
-            "<<<[EOL-LF]>>>" => "\n",
-            "<<<[EOL-CR]>>>" => "\r",
-        ];
-
         // https://regex101.com/r/gJ1oF2/1
         if (preg_match('/^<(\*?[\w\d\\\\]+\*?)> ?(.*)/', $value, $matches)) {
             $type = $matches[1]; // detect type and value from eg. `<boolean> false`
@@ -311,8 +305,7 @@ class SerializedDataToIniConverter
         if ($type !== null && is_string($value)) {
             $value = '<' . $type . '>' . $value;
         }
-        $valueWithoutEolPlaceholders = str_replace(array_keys($eolReplacement), array_values($eolReplacement), $value);
-        return 's:' . strlen($valueWithoutEolPlaceholders) . ':"' . $value . '";';
+        return 's:' . strlen($value) . ':"' . $value . '";';
     }
 
     /**

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -829,6 +829,52 @@ INI
     /**
      * @test
      */
+    public function serializedHTMLString()
+    {
+        $arrayWithHtml = ["meta_key" => "who_is_the_best", "meta_value" => "<p>VersionPress</p>"];
+        $serializedString = serialize($arrayWithHtml);
+        $data = ["Section" => ["data" => $serializedString]];
+        $ini = StringUtils::crlfize(<<<'INI'
+[Section]
+data = <<<serialized>>> <array>
+data["meta_key"] = "who_is_the_best"
+data["meta_value"] = "<p>VersionPress</p>"
+
+INI
+        );
+
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+        
+    }
+
+    /**
+     * @test
+     */
+    public function serializedStringWithNewLines()
+    {
+        $arrayWithHtml = ["meta_key" => "who_is_the_best", "meta_value" => "VersionPress\r\nis\r\nthe\r\nbest"];
+        $serializedString = serialize($arrayWithHtml);
+        $data = ["Section" => ["data" => $serializedString]];
+        $ini = StringUtils::crlfize(<<<'INI'
+[Section]
+data = <<<serialized>>> <array>
+data["meta_key"] = "who_is_the_best"
+data["meta_value"] = "VersionPress
+is
+the
+best"
+
+INI
+        );
+
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+
+    }
+    /**
+     * @test
+     */
     public function serializedOption()
     {
         $sidebarWidgets = [

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -853,8 +853,8 @@ INI
      */
     public function serializedStringWithNewLines()
     {
-        $arrayWithHtml = ["meta_key" => "who_is_the_best", "meta_value" => "VersionPress\r\nis\r\nthe\r\nbest"];
-        $serializedString = serialize($arrayWithHtml);
+        $arrayWithNewLines = ["meta_key" => "who_is_the_best", "meta_value" => "VersionPress\r\nis\r\nthe\r\nbest"];
+        $serializedString = serialize($arrayWithNewLines);
         $data = ["Section" => ["data" => $serializedString]];
         $ini = StringUtils::crlfize(<<<'INI'
 [Section]


### PR DESCRIPTION
Resolves #1002 .

Also fix of incorrect computation of the string length when it contains newlines.

Reviewers:

- [x] @JanVoracek 

Thank you.