### PR TITLE
More reliable implementation of `WpAutomation::ensureCleanInstallationIsAvailable()`

### DIFF
--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -557,12 +557,17 @@ class WpAutomation
     private function ensureCleanInstallationIsAvailable()
     {
 
-        if (!is_dir($this->getCleanInstallationPath())) {
-            $downloadPath = $this->getCleanInstallationPath();
-            FileSystem::mkdir($downloadPath);
+        $cleanInstallationPath = $this->getCleanInstallationPath();
+
+        if (!is_dir($cleanInstallationPath) || !is_file($cleanInstallationPath . '/wp-settings.php')) {
+            if (!is_dir($cleanInstallationPath)) {
+                FileSystem::mkdir($cleanInstallationPath);
+            } else {
+                FileSystem::removeContent($cleanInstallationPath);
+            }
             $wpVersion = $this->siteConfig->wpVersion;
             $wpLocale = $this->siteConfig->wpLocale;
-            $downloadCommand = "wp core download --path=\"$downloadPath\" --version=\"$wpVersion\"";
+            $downloadCommand = "wp core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
             if ($wpLocale) {
                 $downloadCommand .= " --locale=$wpLocale";
             }

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -559,12 +559,10 @@ class WpAutomation
 
         $cleanInstallationPath = $this->getCleanInstallationPath();
 
-        if (!is_dir($cleanInstallationPath) || !is_file($cleanInstallationPath . '/wp-settings.php')) {
-            if (!is_dir($cleanInstallationPath)) {
-                FileSystem::mkdir($cleanInstallationPath);
-            } else {
-                FileSystem::removeContent($cleanInstallationPath);
-            }
+        if (!$this->isCorrectlyDownloaded($cleanInstallationPath)) {
+            FileSystem::remove($cleanInstallationPath);
+            FileSystem::mkdir($cleanInstallationPath);
+
             $wpVersion = $this->siteConfig->wpVersion;
             $wpLocale = $this->siteConfig->wpLocale;
             $downloadCommand = "wp core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
@@ -575,6 +573,19 @@ class WpAutomation
             $this->exec($downloadCommand, null);
         }
     }
+
+    /**
+     * Checks that clean WP installation is available and downloaded correctly. (Simple implementation
+     * for now, just checking some basic paths.)
+     *
+     * @param string $cleanInstallationPath
+     * @return bool
+     */
+    private function isCorrectlyDownloaded($cleanInstallationPath)
+    {
+        return is_dir($cleanInstallationPath) && is_file($cleanInstallationPath . '/wp-settings.php');
+    }
+
 
     /**
      * Returns a path where a clean installation of the configured WP version is stored and cached.


### PR DESCRIPTION
Resolves #1059

Added basic check that `<cached-WP-installation>/wp-settings.php` exists. If not, will re-download the WP version from wordpress.org.

Reviewers:

- [x] @JanVoracek 