### PR TITLE
.git permission fix for Windows

### DIFF
--- a/plugins/versionpress/src/Utils/FileSystem.php
+++ b/plugins/versionpress/src/Utils/FileSystem.php
@@ -27,6 +27,7 @@ class FileSystem
     public static function rename($origin, $target, $overwrite = false)
     {
 
+        self::possiblyFixGitPermissions($origin);
 
         $fs = new \Symfony\Component\Filesystem\Filesystem();
         $fs->rename($origin, $target, $overwrite);
@@ -42,6 +43,7 @@ class FileSystem
     public static function remove($path)
     {
 
+        self::possiblyFixGitPermissions($path);
 
         $fs = new \Symfony\Component\Filesystem\Filesystem();
         $fs->remove($path);
@@ -64,6 +66,11 @@ class FileSystem
             RecursiveIteratorIterator::CHILD_FIRST
         );
 
+        foreach ($iterator as $item) {
+            if ($item->isDir() && Strings::endsWith($iterator->key(), ".git")) {
+                self::possiblyFixGitPermissions($iterator->key());
+            }
+        }
 
         $fs = new \Symfony\Component\Filesystem\Filesystem();
         $fs->remove($iterator);
@@ -112,7 +119,40 @@ class FileSystem
         $fs = new \Symfony\Component\Filesystem\Filesystem();
         $fs->mkdir($dir, $mode);
     }
-    
+
+    /**
+     * If the path is either a `.git` repository itself or a directory that contains it,
+     * this method attempts to set correct permissions on the `.git` folder to avoid issues
+     * on Windows.
+     *
+     * @param $path
+     */
+    private static function possiblyFixGitPermissions($path)
+    {
+
+        $gitDir = null;
+        if (is_dir($path)) {
+            if (basename($path) == '.git') {
+                $gitDir = $path;
+            } else {
+                if (is_dir($path . '/.git')) {
+                    $gitDir = $path . '/.git';
+                }
+            }
+        }
+
+        if ($gitDir) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($gitDir));
+
+            foreach ($iterator as $item) {
+                if (is_dir($item)) {
+                    chmod($item, 0750);
+                } else {
+                    chmod($item, 0640);
+                }
+            }
+        }
+    }
 
     /**
      * Compares two files and returns true if their contents is equal


### PR DESCRIPTION
Resolves #945

Reverts PR #1051 (I probably didn't test it properly) and improves the implementation of the `possiblyFixGitPermissions()` method so that it doesn't cause the permission bug reported in #945.

Reviewers:

- [x] @JanVoracek 