### PR TITLE
Plugins, themes and WordPress installed via Composer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var composer = require('gulp-composer');
 var git = require('gulp-git');
 var merge = require('merge-stream');
 var runSequence = require('run-sequence');
+var execSync = require('child_process').execSync;
 
 
 /**
@@ -91,7 +92,7 @@ gulp.task('prepare-test-deploy', false, function () {
     if (isRelative(sitePath)) {
         sitePath = vpDir + '/tests/' + sitePath;
     }
-    buildDir = sitePath + "/wp-content/plugins/versionpress";
+    buildDir = execSync('wp eval "echo WP_PLUGIN_DIR;"', {cwd: sitePath, encoding: 'utf8'}) + '/versionpress';
 
     isTestDeployBuild = true;
 });

--- a/plugins/versionpress/composer.json
+++ b/plugins/versionpress/composer.json
@@ -9,7 +9,8 @@
     "michelf/php-markdown": "1.4.*",
     "symfony/filesystem": "~2.5",
     "imnotjames/curlfile-compat": "0.0.1",
-    "udan11/sql-parser": "^3.0"
+    "udan11/sql-parser": "^3.0",
+    "composer/composer": "^1.0"
   },
   "config": {
     "platform": {

--- a/plugins/versionpress/composer.lock
+++ b/plugins/versionpress/composer.lock
@@ -4,9 +4,207 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "702537ab3834d639048af07cc207babd",
-    "content-hash": "c3fb5afcc0541a0e4a0252b209a50e1a",
+    "hash": "67645e34edab5008d67f712466e949b8",
+    "content-hash": "333b4cd65acac0e8cfb8823253c05a22",
     "packages": [
+        {
+            "name": "composer/composer",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "a4a0546ece469cae984219f920c75437820064ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/a4a0546ece469cae984219f920c75437820064ff",
+                "reference": "a4a0546ece469cae984219f920c75437820064ff",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.0",
+                "composer/spdx-licenses": "^1.0",
+                "justinrainbow/json-schema": "^1.6",
+                "php": "^5.3.2 || ^7.0",
+                "seld/cli-prompt": "^1.0",
+                "seld/jsonlint": "^1.4",
+                "seld/phar-utils": "^1.0",
+                "symfony/console": "^2.5 || ^3.0",
+                "symfony/filesystem": "^2.5 || ^3.0",
+                "symfony/finder": "^2.2 || ^3.0",
+                "symfony/process": "^2.1 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+                "ext-zip": "Enabling the zip extension allows you to unzip archives",
+                "ext-zlib": "Allow gzip compression of HTTP requests"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "time": "2016-04-29 15:30:16"
+        },
+        {
+            "name": "composer/semver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "84c47f3d8901440403217afc120683c7385aecb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/84c47f3d8901440403217afc120683c7385aecb8",
+                "reference": "84c47f3d8901440403217afc120683c7385aecb8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-03-30 13:16:03"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "88c26372b1afac36d8db601cdf04ad8716f53d88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/88c26372b1afac36d8db601cdf04ad8716f53d88",
+                "reference": "88c26372b1afac36d8db601cdf04ad8716f53d88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "time": "2016-05-04 12:27:30"
+        },
         {
             "name": "imnotjames/curlfile-compat",
             "version": "0.0.1",
@@ -51,6 +249,72 @@
                 "file upload"
             ],
             "time": "2014-06-28 15:19:17"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "f9e27c3e202faf14fd581ef41355d83bb4b7eb7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/f9e27c3e202faf14fd581ef41355d83bb4b7eb7d",
+                "reference": "f9e27c3e202faf14fd581ef41355d83bb4b7eb7d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "json-schema/json-schema-test-suite": "1.1.0",
+                "phpdocumentor/phpdocumentor": "~2",
+                "phpunit/phpunit": "~3.7"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2016-01-06 14:37:04"
         },
         {
             "name": "michelf/php-markdown",
@@ -158,6 +422,202 @@
             "time": "2015-12-03 01:32:27"
         },
         {
+            "name": "seld/cli-prompt",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4",
+                "reference": "8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2016-04-18 09:31:41"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "66834d3e3566bb5798db7294619388786ae99394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/66834d3e3566bb5798db7294619388786ae99394",
+                "reference": "66834d3e3566bb5798db7294619388786ae99394",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "time": "2015-11-21 02:21:41"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/7009b5139491975ef6486545a39f3e6dad5ac30a",
+                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\PharUtils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phra"
+            ],
+            "time": "2015-10-13 18:44:15"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.6.13",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-26 09:08:40"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v2.6.13",
             "target-dir": "Symfony/Component/Filesystem",
@@ -206,6 +666,56 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-08 05:59:48"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.6.13",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "203a10f928ae30176deeba33512999233181dd28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/203a10f928ae30176deeba33512999233181dd28",
+                "reference": "203a10f928ae30176deeba33512999233181dd28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-09 16:02:48"
         },
         {
             "name": "symfony/process",

--- a/plugins/versionpress/ruleset.xml
+++ b/plugins/versionpress/ruleset.xml
@@ -14,6 +14,7 @@
         <exclude-pattern type="relative">bootstrap.php</exclude-pattern>
         <exclude-pattern type="relative">src/Api/VersionPressApi.php</exclude-pattern>
         <exclude-pattern type="relative">src/Cli/vp.php</exclude-pattern>
+        <exclude-pattern type="relative">src/Cli/vp-composer.php</exclude-pattern>
         <exclude-pattern type="relative">src/Cli/vp-internal.php</exclude-pattern>
         <exclude-pattern type="relative">versionpress.php</exclude-pattern>
         <exclude-pattern type="relative">setup-hooks.php</exclude-pattern>

--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -33,7 +33,7 @@ defined('ABSPATH') or die("Direct access not allowed");
 
 if (defined('WP_CLI') && WP_CLI) {
     require_once(__DIR__ . '/src/Cli/vp.php');
-    WP_CLI::add_command('vp', VPCommand::class);
+    require_once(__DIR__ . '/src/Cli/vp-composer.php');
 }
 
 if (defined('VP_MAINTENANCE')) {

--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -369,11 +369,26 @@ function vp_register_hooks()
         return $actions;
     }, 10, 2);
 
-    add_action('vp_revert', function () {
+    add_action('vp_revert', function ($modifiedFiles) {
         // We have to flush the rewrite rules in the next request, because
         // in the current one the changed rewrite rules are not yet effective.
         set_transient('vp_flush_rewrite_rules', 1);
         vp_flush_regenerable_options();
+
+        // Update composer dependencies
+        if (array_search('composer.lock', $modifiedFiles) || array_search('composer.json', $modifiedFiles)) {
+            putenv('COMPOSER_HOME=' . VP_PROJECT_ROOT . '/vendor/bin/composer');
+            $originalCwd = getcwd();
+            chdir(VP_PROJECT_ROOT);
+
+            $input = new \Symfony\Component\Console\Input\ArrayInput(['command' => 'install']);
+            $output = new \Symfony\Component\Console\Output\NullOutput();
+            $application = new \Composer\Console\Application();
+            $application->setAutoExit(false); // prevent `$application->run` method from exitting the script
+            $application->run($input, $output);
+            $application->getComposer();
+            chdir($originalCwd);
+        }
     });
 
     add_action('pre_delete_term', function ($term, $taxonomy) use ($database, $wpdbMirrorBridge) {

--- a/plugins/versionpress/src/ChangeInfos/BulkComposerChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/BulkComposerChangeInfo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace VersionPress\ChangeInfos;
+
+use Nette\Utils\Strings;
+use VersionPress\Utils\StringUtils;
+
+class BulkComposerChangeInfo extends BulkChangeInfo
+{
+
+    public function getChangeDescription()
+    {
+        return sprintf(
+            "%s %d Composer packages",
+            Strings::capitalize(StringUtils::verbToPastTense($this->getAction())),
+            $this->count
+        );
+    }
+}

--- a/plugins/versionpress/src/ChangeInfos/ChangeInfoEnvelope.php
+++ b/plugins/versionpress/src/ChangeInfos/ChangeInfoEnvelope.php
@@ -46,6 +46,7 @@ class ChangeInfoEnvelope implements ChangeInfo
         "user" => BulkUserChangeInfo::class,
         "usermeta" => BulkUserMetaChangeInfo::class,
         "versionpress" => BulkRevertChangeInfo::class,
+        "composer" => ComposerChangeInfo::class,
     ];
 
     /**

--- a/plugins/versionpress/src/ChangeInfos/ChangeInfoMatcher.php
+++ b/plugins/versionpress/src/ChangeInfos/ChangeInfoMatcher.php
@@ -39,6 +39,9 @@ class ChangeInfoMatcher
         "commentmeta/.*" => CommentMetaChangeInfo::class,
         "user/.*" => UserChangeInfo::class,
 
+        // Other actions
+        "composer/.*" => ComposerChangeInfo::class,
+
         // Unknown action:
         "" => UntrackedChangeInfo::class,
 

--- a/plugins/versionpress/src/ChangeInfos/ComposerChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/ComposerChangeInfo.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace VersionPress\ChangeInfos;
+
+use Nette\Utils\Strings;
+use VersionPress\Git\CommitMessage;
+use VersionPress\Utils\StringUtils;
+
+/**
+ * Changes in Composer packages like installation, uninstallation, update.
+ *
+ * VP tags:
+ *
+ *     VP-Action: composer/(install|update|delete)/symfony/process
+ *
+ */
+class ComposerChangeInfo extends TrackedChangeInfo
+{
+
+    private static $OBJECT_TYPE = "composer";
+
+    /** @var string */
+    private $packageName;
+
+    /** @var string */
+    private $action;
+
+    /**
+     * @param string $packageName Name of Composer package.
+     * @param string $action See VP-Action tag documentation in the class docs
+     */
+    public function __construct($packageName, $action)
+    {
+        $this->packageName = $packageName;
+        $this->action = $action;
+    }
+
+    public function getEntityName()
+    {
+        return self::$OBJECT_TYPE;
+    }
+
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    public static function buildFromCommitMessage(CommitMessage $commitMessage)
+    {
+        $actionTag = $commitMessage->getVersionPressTag(TrackedChangeInfo::ACTION_TAG);
+        list(, $action, $packageName) = explode("/", $actionTag, 3);
+        return new self($packageName, $action);
+    }
+
+    public function getChangeDescription()
+    {
+        return sprintf(
+            "%s Composer package '%s'",
+            Strings::capitalize(StringUtils::verbToPastTense($this->action)),
+            $this->packageName
+        );
+    }
+
+    protected function getActionTagValue()
+    {
+        return "{$this->getEntityName()}/{$this->getAction()}/" . $this->packageName;
+    }
+
+    public function getChangedFiles()
+    {
+        return [
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.json'],
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.lock'],
+        ];
+    }
+
+    public function getCustomTags()
+    {
+        return [];
+    }
+}

--- a/plugins/versionpress/src/ChangeInfos/PluginChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/PluginChangeInfo.php
@@ -105,7 +105,11 @@ class PluginChangeInfo extends TrackedChangeInfo
 
         $pluginChange = ["type" => "path", "path" => $pluginPath];
         $optionChange = ["type" => "path", "path" => VP_VPDB_DIR];
+        $composerChanges = [
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.json'],
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.lock'],
+        ];
 
-        return [$pluginChange, $optionChange];
+        return array_merge([$pluginChange, $optionChange], $composerChanges);
     }
 }

--- a/plugins/versionpress/src/ChangeInfos/Sorting/SortingStrategy.php
+++ b/plugins/versionpress/src/ChangeInfos/Sorting/SortingStrategy.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use VersionPress\ChangeInfos\BulkChangeInfo;
 use VersionPress\ChangeInfos\CommentChangeInfo;
 use VersionPress\ChangeInfos\CommentMetaChangeInfo;
+use VersionPress\ChangeInfos\ComposerChangeInfo;
 use VersionPress\ChangeInfos\EntityChangeInfo;
 use VersionPress\ChangeInfos\OptionChangeInfo;
 use VersionPress\ChangeInfos\PluginChangeInfo;
@@ -43,6 +44,7 @@ class SortingStrategy
         RevertChangeInfo::class,
         PluginChangeInfo::class,
         ThemeChangeInfo::class,
+        ComposerChangeInfo::class,
         TermChangeInfo::class,
         TermTaxonomyChangeInfo::class,
         TranslationChangeInfo::class,

--- a/plugins/versionpress/src/ChangeInfos/ThemeChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/ThemeChangeInfo.php
@@ -82,7 +82,12 @@ class ThemeChangeInfo extends TrackedChangeInfo
     {
         $themeChange = ["type" => "path", "path" => $path = WP_CONTENT_DIR . "/themes/" . $this->themeId . "/*"];
         $optionChange = ["type" => "all-storage-files", "entity" => "option"];
-        return [$themeChange, $optionChange];
+        $composerChanges = [
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.json'],
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.lock'],
+        ];
+
+        return array_merge([$themeChange, $optionChange], $composerChanges);
     }
 
     protected function getActionTagValue()

--- a/plugins/versionpress/src/ChangeInfos/WordPressUpdateChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/WordPressUpdateChangeInfo.php
@@ -104,6 +104,9 @@ class WordPressUpdateChangeInfo extends TrackedChangeInfo
 
             // Translations
             ["type" => "path", "path" => WP_CONTENT_DIR . '/languages/*'],
+
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.json'],
+            ["type" => "path", "path" => VP_PROJECT_ROOT . '/composer.lock'],
         ];
     }
 }

--- a/plugins/versionpress/src/Cli/vp-composer.php
+++ b/plugins/versionpress/src/Cli/vp-composer.php
@@ -1,0 +1,121 @@
+<?php
+// NOTE: VersionPress must be fully activated for these commands to be available
+
+// WORD-WRAPPING of the doc comments: 75 chars for option description, 90 chars for everything else,
+// see http://wp-cli.org/docs/commands-cookbook/#longdesc.
+// In this source file, wrap long desc at col 97 and option desc at col 84.
+
+namespace VersionPress\Cli;
+
+use VersionPress\ChangeInfos\PluginChangeInfo;
+use VersionPress\DI\VersionPressServices;
+use VersionPress\Git\Committer;
+use VersionPress\Utils\Process;
+use VersionPress\VersionPress;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * VersionPress CLI commands for Composer scripts.
+ */
+class VPComposerCommand extends WP_CLI_Command
+{
+    /**
+     * Commits all changes made by Composer.
+     *
+     * @subcommand commit-composer-changes
+     */
+    public function commitComposerChanges($args, $assoc_args)
+    {
+        global $versionPressContainer;
+
+        if (!VersionPress::isActive()) {
+            WP_CLI::error('VersionPress is not active. Changes will be not committed.');
+        }
+
+        /** @var Committer $committer */
+        $committer = $versionPressContainer->resolve(VersionPressServices::COMMITTER);
+        $changes = $this->detectChanges();
+        $installedPackages = $changes['installed'];
+        $removedPackages = $changes['removed'];
+        $updatedPackages = $changes['updated'];
+
+        $changeInfos = array_merge(
+            array_map(function ($package) {
+                if ($package['type'] === 'wordpress-plugin') {
+                    return new PluginChangeInfo($package['name'], 'install', $package['name']);
+                }
+
+                return null;
+
+            }, $installedPackages),
+            array_map(function ($package) {
+                if ($package['type'] === 'wordpress-plugin') {
+                    return new PluginChangeInfo($package['name'], 'delete', $package['name']);
+                }
+
+                return null;
+
+            }, $removedPackages),
+            array_map(function ($package) {
+                if ($package['type'] === 'wordpress-plugin') {
+                    return new PluginChangeInfo($package['name'], 'update', $package['name']);
+                }
+
+                return null;
+
+            }, $updatedPackages)
+        );
+
+        var_dump($changeInfos);
+    }
+
+    private function detectChanges()
+    {
+        $currentComposerLock = file_get_contents(VP_PROJECT_ROOT . '/composer.lock');
+
+        $process = new Process(VP_GIT_BINARY . ' show HEAD:composer.lock', VP_PROJECT_ROOT);
+        $process->run();
+
+        $previousComposerLock = $process->getOutput();
+
+        $currentPackages = $this->getPackagesFromLockFile($currentComposerLock);
+        $previousPackages = $this->getPackagesFromLockFile($previousComposerLock);
+
+        $installedPackages = array_diff_key($currentPackages, $previousPackages);
+        $removedPackages = array_diff_key($previousPackages, $currentPackages);
+
+        $packagesWithChangedVersion = array_filter(
+            array_intersect_key($previousPackages, $currentPackages),
+            function ($package) use ($currentPackages) {
+                return $package['version'] !== $currentPackages[$package['name']]['version'];
+            }
+        );
+
+        return [
+            'installed' => $installedPackages,
+            'removed' => $removedPackages,
+            'updated' => $packagesWithChangedVersion,
+        ];
+    }
+
+    private function getPackagesFromLockFile($lockFileContent)
+    {
+        $lockFile = json_decode($lockFileContent, true);
+        return array_combine(
+            array_column($lockFile['packages'], 'name'),
+            array_map(function ($package) {
+                return [
+                    'name' => $package['name'],
+                    'version' => $package['version'],
+                    'type' => $package['type'],
+                    'homepage' => @$package['homepage'] ?: null,
+                ];
+            }, $lockFile['packages'])
+        );
+    }
+}
+
+if (defined('WP_CLI') && WP_CLI) {
+    WP_CLI::add_command('vp-composer', VPComposerCommand::class);
+}

--- a/plugins/versionpress/src/Cli/vp-internal.php
+++ b/plugins/versionpress/src/Cli/vp-internal.php
@@ -145,6 +145,16 @@ class VPInternalCommand extends WP_CLI_Command
             WP_CLI::error("Working directory couldn't be reset");
         }
 
+        // Install current Composer dependencies
+        if (file_exists(VP_PROJECT_ROOT . '/composer.json')) {
+            $process = VPCommandUtils::exec('composer install', VP_PROJECT_ROOT);
+            if ($process->isSuccessful()) {
+                WP_CLI::success('Installed Composer dependencies');
+            } else {
+                WP_CLI::error('Composer dependencies could not be restored.');
+            }
+        }
+
         // Run synchronization
         /** @var SynchronizationProcess $syncProcess */
         $syncProcess = $versionPressContainer->resolve(VersionPressServices::SYNCHRONIZATION_PROCESS);

--- a/plugins/versionpress/src/Cli/vp-internal.php
+++ b/plugins/versionpress/src/Cli/vp-internal.php
@@ -9,6 +9,7 @@ use VersionPress\Git\MergeDriverInstaller;
 use VersionPress\Initialization\Initializer;
 use VersionPress\Initialization\WpConfigSplitter;
 use VersionPress\Synchronizers\SynchronizationProcess;
+use VersionPress\Utils\WordPressMissingFunctions;
 use VersionPress\Utils\WpConfigEditor;
 use WP_CLI;
 use WP_CLI_Command;
@@ -237,12 +238,13 @@ class VPInternalCommand extends WP_CLI_Command
      */
     public function updateConfig($args = [], $assoc_args = [])
     {
-        $wpConfigPath = \WP_CLI\Utils\locate_wp_config();
-        $updateCommonConfig = isset($assoc_args['common']);
-
         require_once __DIR__ . '/VPCommandUtils.php';
         require_once __DIR__ . '/../Initialization/WpConfigSplitter.php';
         require_once __DIR__ . '/../Utils/WpConfigEditor.php';
+        require_once __DIR__ . '/../Utils/WordPressMissingFunctions.php';
+
+        $wpConfigPath = WordPressMissingFunctions::getWpConfigPath();
+        $updateCommonConfig = isset($assoc_args['common']);
 
         if ($updateCommonConfig) {
             $wpConfigPath = dirname($wpConfigPath) . '/' . WpConfigSplitter::COMMON_CONFIG_NAME;

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -205,6 +205,14 @@ class VPCommand extends WP_CLI_Command
     public function restoreSite($args, $assoc_args)
     {
 
+        if (file_exists(getcwd() . '/composer.json')) {
+            $proc = proc_open("composer install", [1 => ["pipe","w"], ["pipe","w"]], $_);
+            $result = proc_close($proc);
+            if ($result !== 0) {
+                WP_CLI::error('Composer dependencies could not be restored.');
+            }
+        }
+
         defined('SHORTINIT') or define('SHORTINIT', true);
 
         require_once __DIR__ . '/../Initialization/WpConfigSplitter.php';

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -1088,10 +1088,17 @@ class VPCommand extends WP_CLI_Command
             $environmentConstant => $environment,
         ];
 
-        $this->runVPInternalCommand('update-config', ['table_prefix', $dbPrefix, 'variable' => null], $clonePath);
+        $process = $this->runVPInternalCommand(
+            'update-config',
+            ['table_prefix', $dbPrefix, 'variable' => null],
+            $clonePath
+        );
+
+        echo $process->getConsoleOutput();
 
         foreach ($replacements as $constant => $value) {
-            $this->runVPInternalCommand('update-config', [$constant, $value], $clonePath);
+            $process = $this->runVPInternalCommand('update-config', [$constant, $value], $clonePath);
+            echo $process->getConsoleOutput();
         }
 
         WP_CLI::success("wp-config.php updated");

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -233,8 +233,10 @@ class VPCommand extends WP_CLI_Command
         $url = $assoc_args['siteurl'];
 
         // Update URLs in wp-config.php
+        define('VP_INDEX_DIR', dirname(\WP_CLI\Utils\locate_wp_config())); // just for the following method
         $this->setConfigUrl('WP_CONTENT_URL', 'WP_CONTENT_DIR', ABSPATH . 'wp-content', $url);
         $this->setConfigUrl('WP_PLUGIN_URL', 'WP_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins', $url);
+        $this->setConfigUrl('WP_HOME', 'VP_INDEX_DIR', VP_PROJECT_ROOT, $url);
 
         WpConfigSplitter::ensureCommonConfigInclude($wpConfigPath);
 
@@ -1172,9 +1174,9 @@ class VPCommand extends WP_CLI_Command
     private function setConfigUrl($urlConstant, $pathConstant, $defaultPath, $baseUrl)
     {
         if (defined($pathConstant) && constant($pathConstant) !== $defaultPath) {
-            $relativePathToWpContent = str_replace(getcwd(), '', realpath(constant($pathConstant)));
-            $url = $baseUrl . str_replace('//', '/', '/' . $relativePathToWpContent);
-
+            $wpConfigDir = dirname(\WP_CLI\Utils\locate_wp_config());
+            $relativePathToWpContent = str_replace($wpConfigDir, '', realpath(constant($pathConstant)));
+            $url = rtrim(rtrim($baseUrl, '/') . str_replace('//', '/', '/' . $relativePathToWpContent), '/');
             $this->runVPInternalCommand('update-config', [$urlConstant, $url]);
         }
     }

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -278,6 +278,10 @@ class VPCommand extends WP_CLI_Command
             WP_CLI::error($process->getConsoleOutput());
         }
 
+        // Fail-safe for gitignored WordPress
+        if (!WpdbReplacer::isReplaced()) {
+            WpdbReplacer::replaceMethods();
+        }
 
         // The next couple of the steps need to be done after WP is fully loaded; we use `finish-init-clone` for that
         // The main reason for this is that we need properly set WP_CONTENT_DIR constant for reading from storages

--- a/plugins/versionpress/src/Git/Reverter.php
+++ b/plugins/versionpress/src/Git/Reverter.php
@@ -408,12 +408,12 @@ class Reverter
         $optionNameRegex = "/^\\[(.*)\\]\\r?$/m";
 
         foreach ($modifiedFiles as $file) {
-            if (!file_exists(ABSPATH . $file) || !is_file(ABSPATH . $file)) {
+            if (!is_file(VP_PROJECT_ROOT . '/' . $file)) {
                 continue;
             }
 
             if (preg_match($optionFileRegex, $file)) {
-                $firstLine = fgets(fopen(ABSPATH . $file, 'r'));
+                $firstLine = fgets(fopen(VP_PROJECT_ROOT . '/' . $file, 'r'));
                 preg_match($optionNameRegex, $firstLine, $optionNameMatch);
                 $vpIds[] = ['vp_id' => $optionNameMatch[1], 'parent' => null];
             }
@@ -422,7 +422,7 @@ class Reverter
             /** @noinspection PhpUsageOfSilenceOperatorInspection */
             $parent = @$matches[0];
 
-            $content = file_get_contents(ABSPATH . $file);
+            $content = file_get_contents(VP_PROJECT_ROOT . '/' . $file);
             preg_match_all($vpIdRegex, $content, $matches);
             $vpIds = array_merge($vpIds, array_map(function ($vpId) use ($parent) {
                 return ['vp_id' => $vpId, 'parent' => $parent];

--- a/plugins/versionpress/src/Git/Reverter.php
+++ b/plugins/versionpress/src/Git/Reverter.php
@@ -128,7 +128,7 @@ class Reverter
 
         $this->synchronizationProcess->synchronize($vpIdsInModifiedFiles);
 
-        do_action('vp_revert');
+        do_action('vp_revert', $modifiedFiles);
         return RevertStatus::OK;
     }
 

--- a/plugins/versionpress/src/Initialization/.gitignore.tpl
+++ b/plugins/versionpress/src/Initialization/.gitignore.tpl
@@ -2,7 +2,7 @@
 #  Main ignored items
 #------------------------
 
-/wp-config.php
+{{abspath-parent}}/wp-config.php
 {{abspath}}/wp-config.php
 .maintenance
 versionpress.maintenance

--- a/plugins/versionpress/src/Initialization/Initializer.php
+++ b/plugins/versionpress/src/Initialization/Initializer.php
@@ -542,9 +542,10 @@ class Initializer
         $vpGitignore = file_get_contents(__DIR__ . '/.gitignore.tpl');
 
         $gitIgnoreVariables = [
-            'wp-content' => '/' . PathUtils::getRelativePath($projectRoot, realpath(WP_CONTENT_DIR)),
-            'wp-plugins' => '/' . PathUtils::getRelativePath($projectRoot, realpath(WP_PLUGIN_DIR)),
-            'abspath' => '/' . PathUtils::getRelativePath($projectRoot, realpath(ABSPATH)),
+            'wp-content' => rtrim('/' . PathUtils::getRelativePath($projectRoot, realpath(WP_CONTENT_DIR)), '/'),
+            'wp-plugins' => rtrim('/' . PathUtils::getRelativePath($projectRoot, realpath(WP_PLUGIN_DIR)), '/'),
+            'abspath' => rtrim('/' . PathUtils::getRelativePath($projectRoot, realpath(ABSPATH)), '/'),
+            'abspath-parent' => rtrim('/' . PathUtils::getRelativePath($projectRoot, realpath(dirname(ABSPATH))), '/'),
         ];
 
         $vpGitignore = StringUtils::fillTemplateString($gitIgnoreVariables, $vpGitignore);

--- a/plugins/versionpress/src/Initialization/Initializer.php
+++ b/plugins/versionpress/src/Initialization/Initializer.php
@@ -131,6 +131,7 @@ class Initializer
             $this->activateVersionPress();
             $this->copyAccessRulesFiles();
             $this->createCommonConfig();
+            $this->installComposerScripts();
             $this->doInitializationCommit($isUpdate);
             vp_disable_maintenance();
             $this->reportProgressChange(InitializerStates::FINISHED);
@@ -634,5 +635,28 @@ class Initializer
         }
 
         return $this->database->get_results("SELECT * FROM {$this->getTableName($entityName)}", ARRAY_A);
+    }
+
+    private function installComposerScripts()
+    {
+        $composerJsonPath = VP_PROJECT_ROOT . '/composer.json';
+        if (!file_exists($composerJsonPath)) {
+            return;
+        }
+
+        $composerJson = json_decode(file_get_contents($composerJsonPath));
+
+        if (!isset($composerJson->scripts)) {
+            $composerJson->scripts = new \stdClass();
+        }
+
+        if ((!isset($composerJson->scripts->{'pre-update-cmd'}) || $composerJson->scripts->{'pre-update-cmd'} === '') &&
+            (!isset($composerJson->scripts->{'post-update-cmd'}) || $composerJson->scripts->{'post-update-cmd'} === '')
+        ) {
+            $composerJson->scripts->{'pre-update-cmd'} = 'wp vp-composer prepare-for-composer-changes';
+            $composerJson->scripts->{'post-update-cmd'} = 'wp vp-composer commit-composer-changes';
+
+            file_put_contents($composerJsonPath, json_encode($composerJson, JSON_PRETTY_PRINT));
+        }
     }
 }

--- a/plugins/versionpress/src/Utils/WordPressMissingFunctions.php
+++ b/plugins/versionpress/src/Utils/WordPressMissingFunctions.php
@@ -8,7 +8,7 @@ class WordPressMissingFunctions
     public static function getWpConfigPath()
     {
         $defaultWpConfigPath = realpath(ABSPATH . 'wp-config.php');
-        $elevatedWpConfigPath = realpath(ABSPATH . '../wp-config.php');
+        $elevatedWpConfigPath = realpath(dirname(ABSPATH) . '/wp-config.php');
 
         if (is_file($defaultWpConfigPath)) {
             return $defaultWpConfigPath;

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -61,7 +61,7 @@ class WpAutomation
         $this->prepareFiles();
         $this->createConfigFile();
         $this->clearDatabase();
-        $this->installWp();
+        $this->installWordPress();
 
         if (!$this->siteConfig->wpAutoupdate) {
             $this->disableAutoUpdate();
@@ -618,7 +618,7 @@ class WpAutomation
      * Installs WordPress. Assumes that files have been prepared on the file system, database is clean
      * and wp-config.php has been created.
      */
-    private function installWp()
+    public function installWordPress()
     {
         $cmdArgs = [
             "url" => $this->siteConfig->url,

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -98,7 +98,7 @@ class WpAutomation
      */
     public function isVersionPressInitialized()
     {
-        $vpdbDir = $this->runWpCliCommand('eval', null, ['defined("VP_VPDB_DIR") && print(VP_VPDB_DIR);']);
+        $vpdbDir = $this->getVpdbDir();
         return $vpdbDir !== '' && is_file($vpdbDir . '/.active');
     }
 
@@ -845,5 +845,64 @@ class WpAutomation
             'update-config',
             [$constant, $value, 'require' => $vpInternalCommandFile]
         );
+    }
+
+    public function getVpdbDir()
+    {
+        static $vpdbDir = false;
+
+        if ($vpdbDir === false) {
+            $vpdbDir = $this->runWpCliCommand('eval', null, ['defined("VP_VPDB_DIR") && print(VP_VPDB_DIR);']) ?: null;
+        }
+
+        return $vpdbDir;
+    }
+
+    public function getAbspath()
+    {
+        static $abspath = false;
+
+        if ($abspath === false) {
+            $abspath = $this->runWpCliCommand('eval', null, ['print(ABSPATH);']) ?: null;
+        }
+
+        return $abspath;
+    }
+
+    public function getUploadsDir()
+    {
+        static $uploads = false;
+
+        if ($uploads === false) {
+            $uploads = $this->runWpCliCommand('eval', null, ['print(wp_upload_dir()["basedir"]);']) ?: null;
+        }
+
+        return $uploads;
+    }
+
+    public function getPluginsDir()
+    {
+        static $pluginsDir = false;
+
+        if ($pluginsDir === false) {
+            $pluginsDir = $this->runWpCliCommand('eval', null, ['print(WP_PLUGIN_DIR);']) ?: null;
+        }
+
+        return $pluginsDir;
+    }
+
+    public function getWebRoot()
+    {
+        static $pluginsDir = false;
+
+        if ($pluginsDir === false) {
+            $pluginsDir = $this->runWpCliCommand(
+                'eval',
+                null,
+                ['print(dirname(\WP_CLI\Utils\locate_wp_config()));']
+            ) ?: null;
+        }
+
+        return $pluginsDir;
     }
 }

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -825,6 +825,11 @@ class WpAutomation
         file_put_contents($bootstrapFile, join("\n", $lines));
     }
 
+    /**
+     * Creates project structure similar to Bedrock.
+     * Pedestal (https://github.com/versionpress/pedestal) is inpired by Bedrock. It only have
+     * a standard wp-config-based configuration system and predefined Composer scripts for VersionPress.
+     */
     private function createPedestalBasedSite()
     {
         $process = new Process('composer create-project -s dev versionpress/pedestal .', $this->siteConfig->path);

--- a/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
+++ b/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
@@ -65,6 +65,8 @@ class WpAutomationRunnerSample extends \PHPUnit_Framework_TestCase
         $wpAutomation->installWordPress();
         $wpAutomation->copyVersionPressFiles();
         $wpAutomation->activateVersionPress();
+
+        $wpAutomation->runWpCliCommand('vp', 'config', ['VP_PROJECT_ROOT', '.']);
     }
 
     /**

--- a/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
+++ b/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
@@ -25,46 +25,6 @@ class WpAutomationRunnerSample extends \PHPUnit_Framework_TestCase
         $wpAutomation->setUpSite();
         $wpAutomation->copyVersionPressFiles();
         $wpAutomation->activateVersionPress();
-    }
-
-    /**
-     * @test
-     */
-    public function createPedestalBasedSite()
-    {
-        $testConfig = TestConfig::createDefaultConfig();
-
-        $testConfig->testSite->url .= '/web';
-        $wpAutomation = new WpAutomation($testConfig->testSite, $testConfig->wpCliVersion);
-
-        FileSystem::remove($testConfig->testSite->path);
-        FileSystem::mkdir($testConfig->testSite->path);
-
-        $process = new Process('composer create-project -s dev versionpress/pedestal .', $testConfig->testSite->path);
-        $process->run();
-
-        function updateConfigConstant(WpAutomation $wpAutomation, $constant, $value, $variable = false)
-        {
-            $vpInternalCommandFile = __DIR__ . '/../../src/Cli/vp-internal.php';
-            $wpAutomation->runWpCliCommand(
-                'vp-internal',
-                'update-config',
-                [$constant, $value, 'require' => $vpInternalCommandFile]
-            );
-        }
-
-        updateConfigConstant($wpAutomation, 'DB_NAME', $testConfig->testSite->dbName);
-        updateConfigConstant($wpAutomation, 'DB_USER', $testConfig->testSite->dbUser);
-        updateConfigConstant($wpAutomation, 'DB_PASSWORD', $testConfig->testSite->dbPassword);
-        updateConfigConstant($wpAutomation, 'DB_HOST', $testConfig->testSite->dbHost);
-        updateConfigConstant($wpAutomation, 'WP_HOME', $testConfig->testSite->url);
-
-        $wpAutomation->runWpCliCommand('db', 'drop', ['yes' => null]);
-        $wpAutomation->runWpCliCommand('db', 'create');
-
-        $wpAutomation->installWordPress();
-        $wpAutomation->copyVersionPressFiles();
-        $wpAutomation->activateVersionPress();
 
         $wpAutomation->runWpCliCommand('vp', 'config', ['VP_PROJECT_ROOT', '.']);
     }

--- a/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
+++ b/plugins/versionpress/tests/Automation/WpAutomationRunner.sample.php
@@ -4,6 +4,8 @@ namespace VersionPress\Tests\Automation;
 
 use VersionPress\Tests\Utils\DBAsserter;
 use VersionPress\Tests\Utils\TestConfig;
+use VersionPress\Utils\FileSystem;
+use VersionPress\Utils\Process;
 
 /**
  * An example of how to run WpAutomation methods from PhpStorm via "unit tests".
@@ -21,6 +23,46 @@ class WpAutomationRunnerSample extends \PHPUnit_Framework_TestCase
         $wpAutomation = new WpAutomation($testConfig->testSite, $testConfig->wpCliVersion);
 
         $wpAutomation->setUpSite();
+        $wpAutomation->copyVersionPressFiles();
+        $wpAutomation->activateVersionPress();
+    }
+
+    /**
+     * @test
+     */
+    public function createPedestalBasedSite()
+    {
+        $testConfig = TestConfig::createDefaultConfig();
+
+        $testConfig->testSite->url .= '/web';
+        $wpAutomation = new WpAutomation($testConfig->testSite, $testConfig->wpCliVersion);
+
+        FileSystem::remove($testConfig->testSite->path);
+        FileSystem::mkdir($testConfig->testSite->path);
+
+        $process = new Process('composer create-project -s dev versionpress/pedestal .', $testConfig->testSite->path);
+        $process->run();
+
+        function updateConfigConstant(WpAutomation $wpAutomation, $constant, $value, $variable = false)
+        {
+            $vpInternalCommandFile = __DIR__ . '/../../src/Cli/vp-internal.php';
+            $wpAutomation->runWpCliCommand(
+                'vp-internal',
+                'update-config',
+                [$constant, $value, 'require' => $vpInternalCommandFile]
+            );
+        }
+
+        updateConfigConstant($wpAutomation, 'DB_NAME', $testConfig->testSite->dbName);
+        updateConfigConstant($wpAutomation, 'DB_USER', $testConfig->testSite->dbUser);
+        updateConfigConstant($wpAutomation, 'DB_PASSWORD', $testConfig->testSite->dbPassword);
+        updateConfigConstant($wpAutomation, 'DB_HOST', $testConfig->testSite->dbHost);
+        updateConfigConstant($wpAutomation, 'WP_HOME', $testConfig->testSite->url);
+
+        $wpAutomation->runWpCliCommand('db', 'drop', ['yes' => null]);
+        $wpAutomation->runWpCliCommand('db', 'create');
+
+        $wpAutomation->installWordPress();
         $wpAutomation->copyVersionPressFiles();
         $wpAutomation->activateVersionPress();
     }

--- a/plugins/versionpress/tests/End2End/Comments/CommentsTest.php
+++ b/plugins/versionpress/tests/End2End/Comments/CommentsTest.php
@@ -29,14 +29,14 @@ class CommentsTest extends End2EndTestCase
 
         self::$worker->prepare_createCommentAwaitingModeration();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createCommentAwaitingModeration();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/create-pending");
-        $commitAsserter->assertCommitPath("A", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/create-pending");
+        $this->commitAsserter->assertCommitPath("A", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -49,12 +49,12 @@ class CommentsTest extends End2EndTestCase
 
         self::$worker->prepare_createSpamComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createSpamComment();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -67,15 +67,15 @@ class CommentsTest extends End2EndTestCase
 
         self::$worker->prepare_createComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/create");
-        $commitAsserter->assertCommitTag("VP-Comment-Author", self::$testConfig->testSite->adminName);
-        $commitAsserter->assertCommitPath("A", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/create");
+        $this->commitAsserter->assertCommitTag("VP-Comment-Author", self::$testConfig->testSite->adminName);
+        $this->commitAsserter->assertCommitPath("A", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -88,15 +88,15 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_editComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/edit");
-        $commitAsserter->assertCommitTag("VP-Comment-Author", self::$testConfig->testSite->adminName);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/edit");
+        $this->commitAsserter->assertCommitTag("VP-Comment-Author", self::$testConfig->testSite->adminName);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -109,14 +109,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_trashComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->trashComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/trash");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/trash");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -129,14 +129,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_untrashComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->untrashComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/untrash");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/untrash");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -149,14 +149,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/delete");
-        $commitAsserter->assertCommitPath("D", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/delete");
+        $this->commitAsserter->assertCommitPath("D", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -169,14 +169,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_unapproveComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->unapproveComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/unapprove");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/unapprove");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -189,14 +189,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_approveComment();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->approveComment();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/approve");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/approve");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -209,14 +209,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_markAsSpam();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->markAsSpam();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/spam");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/spam");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -229,14 +229,14 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_markAsNotSpam();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->markAsNotSpam();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("comment/unspam");
-        $commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("comment/unspam");
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/comments/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -248,13 +248,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_editTwoComments();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editTwoComments();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/edit', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/edit', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -266,13 +266,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteTwoComments();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteTwoComments();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/delete', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/delete', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -284,13 +284,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_moveTwoCommentsInTrash();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->moveTwoCommentsInTrash();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/trash', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/trash', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -302,13 +302,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_moveTwoCommentsFromTrash();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->moveTwoCommentsFromTrash();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/untrash', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/untrash', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -320,13 +320,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_markTwoCommentsAsSpam();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->markTwoCommentsAsSpam();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/spam', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/spam', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -338,13 +338,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_markTwoSpamCommentsAsNotSpam();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->markTwoSpamCommentsAsNotSpam();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/unspam', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/unspam', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -356,13 +356,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_unapproveTwoComments();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->unapproveTwoComments();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/unapprove', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/unapprove', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -374,13 +374,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_approveTwoComments();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->approveTwoComments();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('comment/approve', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('comment/approve', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -392,13 +392,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_commentmetaCreate();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->commentmetaCreate();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("commentmeta/create", 0, true);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("commentmeta/create", 0, true);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -411,13 +411,13 @@ class CommentsTest extends End2EndTestCase
     {
         self::$worker->prepare_commentmetaDelete();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->commentmetaDelete();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("commentmeta/delete", 0, true);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("commentmeta/delete", 0, true);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Comments/CommentsTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Comments/CommentsTestSeleniumWorker.php
@@ -73,7 +73,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     protected function logOut()
     {
-        $this->url('wp-login.php?action=logout');
+        $this->url(dirname(self::$wpAdminPath) . '/wp-login.php?action=logout');
         $this->byCssSelector('body>p>a')->click();
         $this->waitAfterRedirect();
     }
@@ -117,21 +117,21 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function untrashComment()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=trash');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=trash');
         $this->jsClickAndWait('#the-comment-list tr:first-child .untrash a');
     }
 
     public function prepare_deleteComment()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->jsClickAndWait('#the-comment-list tr:first-child .trash a');
-        $this->url('wp-admin/edit-comments.php?comment_status=trash');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=trash');
     }
 
     public function deleteComment()
     {
         $this->jsClickAndWait('#the-comment-list tr:first-child .delete a');
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
     }
 
     public function prepare_unapproveComment()
@@ -141,7 +141,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function unapproveComment()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->jsClickAndWait('#the-comment-list tr:first-child .unapprove a');
     }
 
@@ -151,7 +151,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function approveComment()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=moderated');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=moderated');
         $this->jsClickAndWait('#the-comment-list tr:first-child .approve a');
     }
 
@@ -161,7 +161,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function markAsSpam()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->jsClickAndWait('#the-comment-list tr:first-child .spam a');
     }
 
@@ -171,7 +171,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function markAsNotSpam()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=spam');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=spam');
         $this->jsClickAndWait('#the-comment-list tr:first-child .unspam a');
     }
 
@@ -195,7 +195,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function deleteTwoComments()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=trash');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=trash');
         $this->performBulkActionWithTwoLastComments('delete');
     }
 
@@ -209,7 +209,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function moveTwoCommentsInTrash()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->performBulkActionWithTwoLastComments('trash');
     }
 
@@ -219,7 +219,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function moveTwoCommentsFromTrash()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=trash');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=trash');
         $this->performBulkActionWithTwoLastComments('untrash');
     }
 
@@ -229,7 +229,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function markTwoCommentsAsSpam()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->performBulkActionWithTwoLastComments('spam');
     }
 
@@ -239,7 +239,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function markTwoSpamCommentsAsNotSpam()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=spam');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=spam');
         $this->performBulkActionWithTwoLastComments('unspam');
     }
 
@@ -259,7 +259,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function unapproveTwoComments()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->performBulkActionWithTwoLastComments('unapprove');
     }
 
@@ -269,7 +269,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function approveTwoComments()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=moderated');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=moderated');
         $this->performBulkActionWithTwoLastComments('approve');
     }
 
@@ -298,7 +298,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function commentmetaCreate()
     {
-        $this->url('wp-admin/edit-comments.php');
+        $this->url(self::$wpAdminPath . '/edit-comments.php');
         $this->jsClickAndWait('#the-comment-list tr:first-child .spam a');
     }
 
@@ -308,7 +308,7 @@ class CommentsTestSeleniumWorker extends SeleniumWorker implements ICommentsTest
 
     public function commentmetaDelete()
     {
-        $this->url('wp-admin/edit-comments.php?comment_status=spam');
+        $this->url(self::$wpAdminPath . '/edit-comments.php?comment_status=spam');
         $this->jsClickAndWait('#the-comment-list tr:first-child .unspam a');
     }
 }

--- a/plugins/versionpress/tests/End2End/Media/MediaTest.php
+++ b/plugins/versionpress/tests/End2End/Media/MediaTest.php
@@ -26,17 +26,17 @@ class MediaTest extends End2EndTestCase
     {
         self::$worker->prepare_uploadFile();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->uploadFile();
 
-        $commitAsserter->ignoreCommits(["usermeta/create", "usermeta/edit"]);
+        $this->commitAsserter->ignoreCommits(["usermeta/create", "usermeta/edit"]);
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/create");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
-        $commitAsserter->assertCommitPath("A", "wp-content/uploads/*");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/create");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
+        $this->commitAsserter->assertCommitPath("A", "%uploads%/*");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -49,14 +49,14 @@ class MediaTest extends End2EndTestCase
     {
         self::$worker->prepare_editFileName();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editFileName();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/edit");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/edit");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -69,15 +69,15 @@ class MediaTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteFile();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteFile();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/delete");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
-        $commitAsserter->assertCommitPath("D", "wp-content/uploads/*");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/delete");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
+        $this->commitAsserter->assertCommitPath("D", "%uploads%/*");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -89,15 +89,15 @@ class MediaTest extends End2EndTestCase
     {
         self::$worker->prepare_editFile();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editFile();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/edit");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
-        $commitAsserter->assertCommitPath("A", "wp-content/uploads/*");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/edit");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "attachment");
+        $this->commitAsserter->assertCommitPath("A", "%uploads%/*");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Media/MediaTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Media/MediaTestSeleniumWorker.php
@@ -22,7 +22,7 @@ class MediaTestSeleniumWorker extends SeleniumWorker implements IMediaTestWorker
     {
         // Couldn't find out how to automate the default (and more modern) upload.php so let's go via media-new.php
         // see http://stackoverflow.com/q/27607453/21728
-        $this->url('wp-admin/media-new.php');
+        $this->url(self::$wpAdminPath . '/media-new.php');
         if (!$this->byCssSelector('#html-upload')->displayed()) {
             $this->byCssSelector('.upload-flash-bypass a')->click();
         }

--- a/plugins/versionpress/tests/End2End/Menus/MenusSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Menus/MenusSeleniumWorker.php
@@ -15,7 +15,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function createMenu()
     {
-        $this->url('wp-admin/nav-menus.php?action=edit&menu=0');
+        $this->url(self::$wpAdminPath . '/nav-menus.php?action=edit&menu=0');
         $this->byCssSelector('#menu-name')->clear();
         $this->byCssSelector('#menu-name')->value('Test menu');
         $this->byCssSelector('#save_menu_header')->click();
@@ -28,7 +28,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function editMenu()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $titleInput = $this->byCssSelector('#menu-name');
         $titleInput->clear();
         $titleInput->value('Updated menu');
@@ -42,7 +42,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function addMenuItem()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->addNewMenuItem();
     }
 
@@ -52,7 +52,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function editMenuItem()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->byCssSelector('.menu-item:first-child .item-edit')->click();
         $this->waitForElement('.edit-menu-item-title');
         $titleInput = $this->byCssSelector('.menu-item:first-child .edit-menu-item-title');
@@ -69,7 +69,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function createMenuItemDraft()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->byCssSelector('a[data-type=page-all]')->click();
         $this->byCssSelector('#page-all .menu-item-checkbox:first-of-type')->click();
         $this->byCssSelector('.submit-add-to-menu')->click();
@@ -94,17 +94,18 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
             )
         );
 
+        $pluginsDir = self::$wpAutomation->getPluginsDir();
         $updateConfigArgs = [
             'VERSIONPRESS_GUI',
             'html',
-            'require' => 'wp-content/plugins/versionpress/src/Cli/vp-internal.php'
+            'require' => $pluginsDir . '/versionpress/src/Cli/vp-internal.php'
         ];
         self::$wpAutomation->runWpCliCommand('vp-internal', 'update-config', $updateConfigArgs);
     }
 
     public function deleteOrphanedMenuItems()
     {
-        $this->url('wp-admin/admin.php?page=versionpress/');
+        $this->url(self::$wpAdminPath . '/admin.php?page=versionpress/');
         $this->acceptAlert();
         $this->byCssSelector('.vp-undo:first-of-type')->click();
         $this->waitForAjax();
@@ -116,7 +117,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function removeMenuItem()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->byCssSelector('.menu-item:first-child .item-edit')->click();
         usleep(200 * 1000); // Wait for the UI animation
         $this->byCssSelector('.menu-item:first-child .item-delete')->click();
@@ -128,7 +129,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function prepare_removeMenuItemWithChildren()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $menuId = intval($this->byId('menu')->value());
 
         $item = [1, 'title' => 'Parent'];
@@ -143,7 +144,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function removeMenuItemWithChildren()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->byCssSelector('.menu-item:nth-of-type(2) .item-edit')->click();
         usleep(200 * 1000); // Wait for the UI animation
         $this->byCssSelector('.menu-item:nth-of-type(2) .item-delete')->click();
@@ -158,7 +159,7 @@ class MenusTestSeleniumWorker extends SeleniumWorker implements IMenusTestWorker
 
     public function deleteMenu()
     {
-        $this->url('wp-admin/nav-menus.php');
+        $this->url(self::$wpAdminPath . '/nav-menus.php');
         $this->byCssSelector('.menu-delete')->click();
         $this->acceptAlert();
         $this->waitAfterRedirect();

--- a/plugins/versionpress/tests/End2End/Menus/MenusTest.php
+++ b/plugins/versionpress/tests/End2End/Menus/MenusTest.php
@@ -20,15 +20,15 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_createMenu();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createMenu();
 
-        $commitAsserter->ignoreCommits("usermeta/create");
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("term/create");
-        $commitAsserter->assertCommitPath('A', "%vpdb%/terms/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->ignoreCommits("usermeta/create");
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("term/create");
+        $this->commitAsserter->assertCommitPath('A', "%vpdb%/terms/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -41,14 +41,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_editMenu();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editMenu();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("term/rename");
-        $commitAsserter->assertCommitPath('M', "%vpdb%/terms/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("term/rename");
+        $this->commitAsserter->assertCommitPath('M', "%vpdb%/terms/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -61,14 +61,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_addMenuItem();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->addMenuItem();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/create");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/create");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -81,14 +81,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_editMenuItem();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editMenuItem();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/edit");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/edit");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -101,12 +101,12 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_createMenuItemDraft();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createMenuItemDraft();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCountOfUntrackedFiles(1);
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCountOfUntrackedFiles(1);
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -119,12 +119,12 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteOrphanedMenuItems();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteOrphanedMenuItems();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -137,14 +137,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_removeMenuItem();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->removeMenuItem();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/delete");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/delete");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -156,14 +156,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_removeMenuItemWithChildren();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->removeMenuItemWithChildren();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/delete");
-        $commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/delete");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", "nav_menu_item");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -176,14 +176,14 @@ class MenusTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteMenu();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteMenu();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("term/delete");
-        $commitAsserter->assertCommitPath('D', "%vpdb%/terms/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("term/delete");
+        $this->commitAsserter->assertCommitPath('D', "%vpdb%/terms/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Options/OptionsTest.php
+++ b/plugins/versionpress/tests/End2End/Options/OptionsTest.php
@@ -20,14 +20,14 @@ class OptionsTest extends End2EndTestCase
     {
         self::$worker->prepare_changeOption();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->changeOption();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('option/edit');
-        $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('option/edit');
+        $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -39,14 +39,14 @@ class OptionsTest extends End2EndTestCase
     {
         self::$worker->prepare_changeTwoOptions();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->changeTwoOptions();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('option/edit', 2);
-        $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('option/edit', 2);
+        $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Options/OptionsTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Options/OptionsTestSeleniumWorker.php
@@ -9,7 +9,7 @@ class OptionsTestSeleniumWorker extends SeleniumWorker implements IOptionsTestWo
 
     public function prepare_changeOption()
     {
-        $this->url('wp-admin/options-general.php');
+        $this->url(self::$wpAdminPath . '/options-general.php');
     }
 
     public function changeOption()
@@ -21,7 +21,7 @@ class OptionsTestSeleniumWorker extends SeleniumWorker implements IOptionsTestWo
 
     public function prepare_changeTwoOptions()
     {
-        $this->url('wp-admin/options-general.php');
+        $this->url(self::$wpAdminPath . '/options-general.php');
     }
 
     public function changeTwoOptions()

--- a/plugins/versionpress/tests/End2End/Plugins/PluginsTest.php
+++ b/plugins/versionpress/tests/End2End/Plugins/PluginsTest.php
@@ -29,6 +29,10 @@ class PluginsTest extends End2EndTestCase
     {
         parent::setUpBeforeClass();
 
+        if (self::$testConfig->testSite->installationType !== 'standard') {
+            throw new \PHPUnit_Framework_SkippedTestSuiteError();
+        }
+
         $testDataPath = __DIR__ . '/../test-data';
         self::$pluginInfo = [
             'zipfile' => realpath($testDataPath . '/hello-dolly.1.6.zip'),
@@ -75,15 +79,15 @@ class PluginsTest extends End2EndTestCase
     {
         self::$worker->prepare_installPlugin();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->installPlugin();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("plugin/install");
-        $commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
-        $commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("plugin/install");
+        $this->commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -96,15 +100,15 @@ class PluginsTest extends End2EndTestCase
     {
         self::$worker->prepare_activatePlugin();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->activatePlugin();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("plugin/activate");
-        $commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("plugin/activate");
+        $this->commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -117,15 +121,15 @@ class PluginsTest extends End2EndTestCase
     {
         self::$worker->prepare_deactivatePlugin();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deactivatePlugin();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("plugin/deactivate");
-        $commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("plugin/deactivate");
+        $this->commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -137,15 +141,15 @@ class PluginsTest extends End2EndTestCase
     public function deletingPluginCreatesPluginDeleteAction()
     {
         self::$worker->prepare_deletePlugin();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deletePlugin();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("plugin/delete");
-        $commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
-        $commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("plugin/delete");
+        $this->commitAsserter->assertCommitTag("VP-Plugin-Name", self::$pluginInfo['name']);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -156,15 +160,15 @@ class PluginsTest extends End2EndTestCase
     public function installingTwoPluginsCreatesBulkAction()
     {
         self::$worker->prepare_installTwoPlugins();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->installTwoPlugins();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('plugin/install', 2);
-        $commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
-        $commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$secondPluginInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('plugin/install', 2);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/plugins/" . self::$secondPluginInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -175,14 +179,14 @@ class PluginsTest extends End2EndTestCase
     public function activatingTwoPluginsCreatesBulkAction()
     {
         self::$worker->prepare_activateTwoPlugins();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->activateTwoPlugins();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('plugin/activate', 2);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('plugin/activate', 2);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -193,14 +197,14 @@ class PluginsTest extends End2EndTestCase
     public function deactivatingTwoPluginsCreatesBulkAction()
     {
         self::$worker->prepare_deactivateTwoPlugins();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deactivateTwoPlugins();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('plugin/deactivate', 2);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('plugin/deactivate', 2);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/options/ac/active_plugins.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -211,15 +215,15 @@ class PluginsTest extends End2EndTestCase
     public function uninstallingTwoPluginsCreatesBulkAction()
     {
         self::$worker->prepare_uninstallTwoPlugins();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->uninstallTwoPlugins();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('plugin/delete', 2);
-        $commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
-        $commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$secondPluginInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('plugin/delete', 2);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$pluginInfo['affected-path']);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/plugins/" . self::$secondPluginInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Plugins/PluginsTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Plugins/PluginsTestSeleniumWorker.php
@@ -23,7 +23,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function prepare_installPlugin()
     {
-        $this->url('wp-admin/plugin-install.php?tab=upload');
+        $this->url(self::$wpAdminPath . '/plugin-install.php?tab=upload');
     }
 
     public function installPlugin()
@@ -35,7 +35,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function prepare_activatePlugin()
     {
-        $this->url("wp-admin/plugins.php");
+        $this->url(self::$wpAdminPath . "/plugins.php");
     }
 
     public function activatePlugin()
@@ -46,7 +46,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function prepare_deactivatePlugin()
     {
-        $this->url("wp-admin/plugins.php");
+        $this->url(self::$wpAdminPath . "/plugins.php");
     }
 
     public function deactivatePlugin()
@@ -84,7 +84,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
             self::$secondPluginInfo['zipfile']
         );
         self::$wpAutomation->runWpCliCommand('plugin', 'install', [$plugin1Path, $plugin2Path]);
-        $this->url("wp-admin/plugins.php");
+        $this->url(self::$wpAdminPath . "/plugins.php");
     }
 
     public function activateTwoPlugins()
@@ -94,7 +94,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function prepare_deactivateTwoPlugins()
     {
-        $this->url("wp-admin/plugins.php");
+        $this->url(self::$wpAdminPath . "/plugins.php");
     }
 
     public function deactivateTwoPlugins()
@@ -104,7 +104,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function prepare_uninstallTwoPlugins()
     {
-        $this->url("wp-admin/plugins.php");
+        $this->url(self::$wpAdminPath . "/plugins.php");
     }
 
     public function uninstallTwoPlugins()

--- a/plugins/versionpress/tests/End2End/Posts/PostsTest.php
+++ b/plugins/versionpress/tests/End2End/Posts/PostsTest.php
@@ -124,16 +124,16 @@ class PostsTest extends PostTypeTestCase
     {
         self::$worker->prepare_createTagInEditationForm();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createTagInEditationForm();
 
-        $commitAsserter->assertNumCommits(2);
-        $commitAsserter->assertCommitAction('post/edit');
-        $commitAsserter->assertCommitAction('term/create', 1);
-        $commitAsserter->assertCommitTag("VP-Post-Type", self::$worker->getPostType());
-        $commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "vp_term_taxonomy");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(2);
+        $this->commitAsserter->assertCommitAction('post/edit');
+        $this->commitAsserter->assertCommitAction('term/create', 1);
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", self::$worker->getPostType());
+        $this->commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "vp_term_taxonomy");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -164,17 +164,17 @@ class PostsTest extends PostTypeTestCase
     public function changingPostFormatUpdatesItsTaxonomy()
     {
         self::$worker->prepare_changePostFormat();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
         self::$worker->changePostFormat();
 
-        $commitAsserter->ignoreCommits('term/create');
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('post/edit');
-        $commitAsserter->assertCommitTag(
+        $this->commitAsserter->ignoreCommits('term/create');
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('post/edit');
+        $this->commitAsserter->assertCommitTag(
             'VP-Post-UpdatedProperties',
             'vp_term_taxonomy,post_modified,post_modified_gmt'
         );
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -230,11 +230,11 @@ class PostsTest extends PostTypeTestCase
     public function deletingOfPostmetaCreatesPostmetaDeleteAction()
     {
         self::$worker->prepare_deletePostmeta();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
         self::$worker->deletePostmeta();
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('postmeta/delete');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('postmeta/delete');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Revert/RevertTest.php
+++ b/plugins/versionpress/tests/End2End/Revert/RevertTest.php
@@ -21,15 +21,15 @@ class RevertTest extends End2EndTestCase
     {
         $changes = self::$worker->prepare_undoLastCommit();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoLastCommit();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -40,15 +40,15 @@ class RevertTest extends End2EndTestCase
     public function undoRevertsOnlyOneCommit()
     {
         $changes = self::$worker->prepare_undoSecondCommit();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoSecondCommit();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -60,16 +60,16 @@ class RevertTest extends End2EndTestCase
     {
         $changes = self::$worker->prepare_undoRevertedCommit();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoLastCommit();
         self::$worker->undoLastCommit();
 
-        $commitAsserter->assertNumCommits(2);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(2);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -81,11 +81,11 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_tryRestoreEntityWithMissingReference();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->tryRestoreEntityWithMissingReference();
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -97,14 +97,14 @@ class RevertTest extends End2EndTestCase
     {
         $changes = self::$worker->prepare_rollbackMoreChanges();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->rollbackMoreChanges();
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/rollback');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/rollback');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -116,12 +116,12 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_clickOnCancel();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->clickOnCancel();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -133,14 +133,14 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_undoWithNotCleanWorkingDirectory();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
         touch(self::$testConfig->testSite->path . '/revert-test-file');
 
         self::$worker->undoLastCommit();
 
-        $commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertNumCommits(0);
         unlink(self::$testConfig->testSite->path . '/revert-test-file');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -160,15 +160,15 @@ class RevertTest extends End2EndTestCase
         VPCommandUtils::exec('git merge test', $sitePath);
         VPCommandUtils::exec('git branch -d test', $sitePath);
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$wpAutomation->runWpCliCommand('vp', 'rollback', [$commitHash]);
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCleanWorkingDirectory();
-        $commitAsserter->assertCountOfAffectedFiles(2);
-        $commitAsserter->assertCommitPath('D', '%vpdb%/options/vp/vp_option_master.ini');
-        $commitAsserter->assertCommitPath('D', '%vpdb%/options/vp/vp_option_test.ini');
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCountOfAffectedFiles(2);
+        $this->commitAsserter->assertCommitPath('D', '%vpdb%/options/vp/vp_option_master.ini');
+        $this->commitAsserter->assertCommitPath('D', '%vpdb%/options/vp/vp_option_test.ini');
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -180,12 +180,12 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_undoToTheSameState();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoSecondCommit();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -197,12 +197,12 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_rollbackToTheSameState();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->rollbackToTheSameState();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -213,15 +213,15 @@ class RevertTest extends End2EndTestCase
     public function undoMultipleCommitsCreatesOneCommit()
     {
         $changes = self::$worker->prepare_undoMultipleCommits();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoMultipleCommits();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -231,15 +231,15 @@ class RevertTest extends End2EndTestCase
     public function undoMultipleCommitsDetectsMissingReferencesCorrectly()
     {
         $changes = self::$worker->prepare_undoMultipleDependentCommits();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoMultipleDependentCommits();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -251,11 +251,11 @@ class RevertTest extends End2EndTestCase
     {
         self::$worker->prepare_undoMultipleCommitsThatCannotBeReverted();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoMultipleCommitsThatCannotBeReverted();
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -267,15 +267,15 @@ class RevertTest extends End2EndTestCase
     {
         $changes = self::$worker->prepare_undoNonDbChange();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->undoNonDbChange();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('versionpress/undo');
-        $commitAsserter->assertCountOfAffectedFiles(count($changes));
-        $commitAsserter->assertCommitPaths($changes);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('versionpress/undo');
+        $this->commitAsserter->assertCountOfAffectedFiles(count($changes));
+        $this->commitAsserter->assertCommitPaths($changes);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Revert/RevertTestWpCliWorker.php
+++ b/plugins/versionpress/tests/End2End/Revert/RevertTestWpCliWorker.php
@@ -186,11 +186,11 @@ class RevertTestWpCliWorker extends WpCliWorker implements IRevertTestWorker
 
     public function prepare_undoNonDbChange()
     {
-        $themeFile = 'wp-content/themes/twentyfifteen/header.php';
-        file_put_contents($this->testConfig->testSite->path . '/' . $themeFile, '');
-        $this->repository->stageAll($themeFile);
+        $newFile = 'vp-file.txt';
+        file_put_contents($this->testConfig->testSite->path . '/' . $newFile, '');
+        $this->repository->stageAll($newFile);
         $this->repository->commit('Manual commit', 'John Tester', 'john.tester@example.com');
-        return [['M', $themeFile]];
+        return [['D', $newFile]];
     }
 
     public function undoNonDbChange()

--- a/plugins/versionpress/tests/End2End/Themes/ThemesTest.php
+++ b/plugins/versionpress/tests/End2End/Themes/ThemesTest.php
@@ -23,6 +23,11 @@ class ThemesTest extends End2EndTestCase
     public static function setupBeforeClass()
     {
         parent::setUpBeforeClass();
+
+        if (self::$testConfig->testSite->installationType !== 'standard') {
+            throw new \PHPUnit_Framework_SkippedTestSuiteError();
+        }
+
         $testDataPath = __DIR__ . '/../test-data';
         self::$themeInfo = [
             'zipfile' => realpath($testDataPath . '/test-theme.zip'),
@@ -50,15 +55,15 @@ class ThemesTest extends End2EndTestCase
     {
         self::$worker->prepare_uploadTheme();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->uploadTheme();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("theme/install");
-        $commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
-        $commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$themeInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("theme/install");
+        $this->commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$themeInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -71,15 +76,15 @@ class ThemesTest extends End2EndTestCase
         self::$worker->prepare_switchTheme();
         $currentTheme = self::$wpAutomation->getCurrentTheme();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->switchTheme();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("theme/switch");
-        $commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
-        $commitAsserter->assertCommitPath(["A", "M"], "%vpdb%/options/cu/current_theme.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("theme/switch");
+        $this->commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
+        $this->commitAsserter->assertCommitPath(["A", "M"], "%vpdb%/options/cu/current_theme.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
 
         self::$wpAutomation->switchTheme($currentTheme);
@@ -93,15 +98,15 @@ class ThemesTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteTheme();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteTheme();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("theme/delete");
-        $commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
-        $commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$themeInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("theme/delete");
+        $this->commitAsserter->assertCommitTag("VP-Theme-Name", self::$themeInfo['name']);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$themeInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -112,15 +117,15 @@ class ThemesTest extends End2EndTestCase
     public function uploadingTwoThemesCreatesBulkAction()
     {
         self::$worker->prepare_uploadTwoThemes();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->uploadTwoThemes();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('theme/install', 2);
-        $commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$themeInfo['affected-path']);
-        $commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$secondThemeInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('theme/install', 2);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$themeInfo['affected-path']);
+        $this->commitAsserter->assertCommitPath("A", "wp-content/themes/" . self::$secondThemeInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -131,15 +136,15 @@ class ThemesTest extends End2EndTestCase
     public function deletingTwoThemesCreatesBulkAction()
     {
         self::$worker->prepare_deleteTwoThemes();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteTwoThemes();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('theme/delete', 2);
-        $commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$themeInfo['affected-path']);
-        $commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$secondThemeInfo['affected-path']);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('theme/delete', 2);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$themeInfo['affected-path']);
+        $this->commitAsserter->assertCommitPath("D", "wp-content/themes/" . self::$secondThemeInfo['affected-path']);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Themes/ThemesTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Themes/ThemesTestSeleniumWorker.php
@@ -21,7 +21,7 @@ class ThemesTestSeleniumWorker extends SeleniumWorker implements IThemesTestWork
 
     public function prepare_uploadTheme()
     {
-        $this->url('wp-admin/theme-install.php?upload');
+        $this->url(self::$wpAdminPath . '/theme-install.php?upload');
     }
 
     public function uploadTheme()
@@ -33,7 +33,7 @@ class ThemesTestSeleniumWorker extends SeleniumWorker implements IThemesTestWork
 
     public function prepare_switchTheme()
     {
-        $this->url('wp-admin/themes.php');
+        $this->url(self::$wpAdminPath . '/themes.php');
     }
 
     public function switchTheme()
@@ -44,7 +44,7 @@ class ThemesTestSeleniumWorker extends SeleniumWorker implements IThemesTestWork
 
     public function prepare_deleteTheme()
     {
-        $this->url('wp-admin/themes.php');
+        $this->url(self::$wpAdminPath . '/themes.php');
     }
 
     public function deleteTheme()

--- a/plugins/versionpress/tests/End2End/Translations/TranslationsTest.php
+++ b/plugins/versionpress/tests/End2End/Translations/TranslationsTest.php
@@ -20,14 +20,14 @@ class TranslationsTest extends End2EndTestCase
     {
         self::$worker->prepare_switchLanguage();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->switchLanguage();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('translation/activate');
-        $commitAsserter->assertCommitPath(['A', 'M'], '%vpdb%/options/*');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('translation/activate');
+        $this->commitAsserter->assertCommitPath(['A', 'M'], '%vpdb%/options/*');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 }

--- a/plugins/versionpress/tests/End2End/Translations/TranslationsTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Translations/TranslationsTestSeleniumWorker.php
@@ -9,7 +9,7 @@ class TranslationsTestSeleniumWorker extends SeleniumWorker implements ITranslat
 
     public function prepare_switchLanguage()
     {
-        $this->url('wp-admin/options-general.php');
+        $this->url(self::$wpAdminPath . '/options-general.php');
     }
 
     public function switchLanguage()

--- a/plugins/versionpress/tests/End2End/Users/UsersTest.php
+++ b/plugins/versionpress/tests/End2End/Users/UsersTest.php
@@ -34,15 +34,15 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_createUser();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createUser();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("user/create");
-        $commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
-        $commitAsserter->assertCommitPath("A", "%vpdb%/users/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("user/create");
+        $this->commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
+        $this->commitAsserter->assertCommitPath("A", "%vpdb%/users/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -55,15 +55,15 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_editUser();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editUser();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("user/edit");
-        $commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("user/edit");
+        $this->commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -76,15 +76,15 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_editUsermeta();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editUsermeta();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("usermeta/edit");
-        $commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID(VP-User-Id)%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("usermeta/edit");
+        $this->commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID(VP-User-Id)%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -97,15 +97,15 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteUser();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteUser();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("user/delete");
-        $commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
-        $commitAsserter->assertCommitPath("D", "%vpdb%/users/%VPID%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("user/delete");
+        $this->commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
+        $this->commitAsserter->assertCommitPath("D", "%vpdb%/users/%VPID%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -117,13 +117,13 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_editTwoUsers();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editTwoUsers();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction("user/edit", 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction("user/edit", 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -135,13 +135,13 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteTwoUsers();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteTwoUsers();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction("user/delete", 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction("user/delete", 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -154,13 +154,13 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_editTwoUsermeta();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editTwoUsermeta();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction("usermeta/edit", 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction("usermeta/edit", 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -172,15 +172,15 @@ class UsersTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteUsermeta();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteUsermeta();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("usermeta/delete");
-        $commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
-        $commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID(VP-User-Id)%.ini");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("usermeta/delete");
+        $this->commitAsserter->assertCommitTag("VP-User-Login", self::$testUser['login']);
+        $this->commitAsserter->assertCommitPath("M", "%vpdb%/users/%VPID(VP-User-Id)%.ini");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 

--- a/plugins/versionpress/tests/End2End/Users/UsersTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Users/UsersTestSeleniumWorker.php
@@ -19,7 +19,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
 
     public function prepare_createUser()
     {
-        $this->url('wp-admin/user-new.php');
+        $this->url(self::$wpAdminPath . '/user-new.php');
     }
 
     public function createUser()
@@ -38,7 +38,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
 
     public function prepare_editUser()
     {
-        $this->url('wp-admin/users.php');
+        $this->url(self::$wpAdminPath . '/users.php');
         $this->jsClick(".username a:contains('{$this->testUser['login']}')");
         $this->waitAfterRedirect();
     }
@@ -55,7 +55,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
 
     public function prepare_editUsermeta()
     {
-        $this->url('wp-admin/users.php');
+        $this->url(self::$wpAdminPath . '/users.php');
         $this->jsClick(".username a:contains('{$this->testUser['login']}')");
         $this->waitAfterRedirect();
     }
@@ -71,7 +71,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
 
     public function prepare_deleteUser()
     {
-        $this->url('wp-admin/users.php');
+        $this->url(self::$wpAdminPath . '/users.php');
         $this->executeScript(
             "jQuery(\"a:contains('{$this->testUser['login']}')\").parents('td').find('.delete a')[0].click()"
         );
@@ -107,7 +107,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
 
     public function deleteTwoUsers()
     {
-        $this->url('wp-admin/users.php');
+        $this->url(self::$wpAdminPath . '/users.php');
 
         foreach ($this->userIds as $id) {
             $this->jsClick("#user-$id .check-column input[type=checkbox]");
@@ -139,7 +139,7 @@ class UsersTestSeleniumWorker extends SeleniumWorker implements IUsersTestWorker
     {
         $this->userIds = self::$wpAutomation->createUser($this->prepareTestUser());
 
-        $this->url('wp-admin/users.php');
+        $this->url(self::$wpAdminPath . '/users.php');
         $this->jsClick("#user-{$this->userIds} .username a");
         $this->waitAfterRedirect();
     }

--- a/plugins/versionpress/tests/End2End/Utils/End2EndTestCase.php
+++ b/plugins/versionpress/tests/End2End/Utils/End2EndTestCase.php
@@ -5,8 +5,10 @@ namespace VersionPress\Tests\End2End\Utils;
 use PHPUnit_Framework_TestCase;
 use VersionPress\Git\GitRepository;
 use VersionPress\Tests\Automation\WpAutomation;
+use VersionPress\Tests\Utils\CommitAsserter;
 use VersionPress\Tests\Utils\TestConfig;
 use VersionPress\Tests\Utils\TestRunnerOptions;
+use VersionPress\Utils\PathUtils;
 
 class End2EndTestCase extends PHPUnit_Framework_TestCase
 {
@@ -15,6 +17,8 @@ class End2EndTestCase extends PHPUnit_Framework_TestCase
     protected static $testConfig;
     /** @var GitRepository */
     protected $gitRepository;
+    /** @var CommitAsserter */
+    protected $commitAsserter;
     /** @var WpAutomation */
     protected static $wpAutomation;
 
@@ -26,6 +30,17 @@ class End2EndTestCase extends PHPUnit_Framework_TestCase
         $this->staticInitialization();
         $this->gitRepository = new GitRepository(self::$testConfig->testSite->path);
         self::$wpAutomation = new WpAutomation(self::$testConfig->testSite, self::$testConfig->wpCliVersion);
+
+        $vpdbDir = self::$wpAutomation->getVpdbDir();
+        $relativePathToVpdb = PathUtils::getRelativePath(self::$testConfig->testSite->path, $vpdbDir);
+
+        $uploadsDir = self::$wpAutomation->getUploadsDir();
+        $relativePathToUploads = PathUtils::getRelativePath(self::$testConfig->testSite->path, $uploadsDir);
+
+        $this->commitAsserter = new CommitAsserter(
+            $this->gitRepository,
+            ['vpdb' => $relativePathToVpdb, 'uploads' => $relativePathToUploads]
+        );
     }
 
     protected function setUp()

--- a/plugins/versionpress/tests/End2End/Utils/PostTypeTestCase.php
+++ b/plugins/versionpress/tests/End2End/Utils/PostTypeTestCase.php
@@ -29,97 +29,97 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_addPost();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->addPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/create");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/create");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
     public function runUpdatePostTest()
     {
         self::$worker->prepare_updatePost();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->updatePost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/edit");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCommitTag(
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/edit");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCommitTag(
             "VP-Post-UpdatedProperties",
             "post_content,post_title,post_modified,post_modified_gmt"
         );
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
     public function runUpdatePostViaQuickEditTest()
     {
         self::$worker->prepare_quickEditPost();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->quickEditPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitsAreEquivalent();
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitsAreEquivalent();
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
         try {
-            $commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "post_title,post_modified,post_modified_gmt");
+            $this->commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "post_title,post_modified,post_modified_gmt");
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             // Since WP 4.2 there is a bug in WP.
             // The ping_status might be changed by the quick edit form.
             // Reported here: https://core.trac.wordpress.org/ticket/31977
-            $commitAsserter->assertCommitTag(
+            $this->commitAsserter->assertCommitTag(
                 "VP-Post-UpdatedProperties",
                 "post_title,ping_status,post_modified,post_modified_gmt"
             );
         }
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
     public function runTrashPostTest()
     {
         self::$worker->prepare_trashPost();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->trashPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/trash");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "post_status,post_modified,post_modified_gmt");
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/trash");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCommitTag("VP-Post-UpdatedProperties", "post_status,post_modified,post_modified_gmt");
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
     public function runUndoTrashTest()
     {
         self::$worker->prepare_untrashPost();
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->untrashPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/untrash");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/untrash");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
         if (WpVersionComparer::compare(TestConfig::createDefaultConfig()->testSite->wpVersion, '4.5') < 0) {
-            $commitAsserter->assertCommitTag(
+            $this->commitAsserter->assertCommitTag(
                 "VP-Post-UpdatedProperties",
                 "post_status,post_modified,post_modified_gmt"
             );
         } else {
-            $commitAsserter->assertCommitTag(
+            $this->commitAsserter->assertCommitTag(
                 "VP-Post-UpdatedProperties",
                 "post_status,post_name,post_modified,post_modified_gmt"
             );
         }
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -127,14 +127,14 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_deletePost();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deletePost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/delete");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/delete");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -142,14 +142,14 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_createDraft();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createDraft();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/draft");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/draft");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -157,12 +157,12 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_previewDraft();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->previewDraft();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
 
         // This time we DO NOT want to assert that files equal database. It's because previewing
         // the post updates `post_date` and similar fields in the database while we don't want
@@ -175,14 +175,14 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_previewUnsavedPost();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->previewUnsavedPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/draft");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/draft");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -190,18 +190,18 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_publishDraft();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->publishDraft();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction("post/publish");
-        $commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
-        $commitAsserter->assertCommitTag(
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction("post/publish");
+        $this->commitAsserter->assertCommitTag("VP-Post-Type", $this->getPostType());
+        $this->commitAsserter->assertCommitTag(
             "VP-Post-UpdatedProperties",
             "post_date,post_date_gmt,post_content,post_status,post_name,post_modified,post_modified_gmt"
         );
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -209,12 +209,12 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_setFeaturedImageForUnsavedPost();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->setFeaturedImageForUnsavedPost();
 
-        $commitAsserter->assertNumCommits(0);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(0);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         // In this case we dont want to check the integrity with database. There is one extra postmeta in the database
         // representing the relation to the featured image. It will be saved in the following test.
     }
@@ -224,14 +224,14 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_makeDraftFromUnsavedPost();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->makeDraftFromUnsavedPost();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('post/draft');
-        $commitAsserter->assertCommitAction('postmeta/create', 0, true);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('post/draft');
+        $this->commitAsserter->assertCommitAction('postmeta/create', 0, true);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -239,13 +239,13 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_changeStatusOfTwoPosts();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->changeStatusOfTwoPosts();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('post/edit', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('post/edit', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -253,13 +253,13 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_moveTwoPostsInTrash();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->moveTwoPostsInTrash();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('post/trash', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('post/trash', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -267,13 +267,13 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_moveTwoPostsFromTrash();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->moveTwoPostsFromTrash();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('post/untrash', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('post/untrash', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -281,13 +281,13 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_deleteTwoPosts();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteTwoPosts();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('post/delete', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('post/delete', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -295,13 +295,13 @@ abstract class PostTypeTestCase extends End2EndTestCase
     {
         self::$worker->prepare_publishTwoPosts();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->publishTwoPosts();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertBulkAction('post/publish', 2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertBulkAction('post/publish', 2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 

--- a/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Utils/PostTypeTestSeleniumWorker.php
@@ -194,7 +194,7 @@ abstract class PostTypeTestSeleniumWorker extends SeleniumWorker implements IPos
      */
     protected function getPostTypeScreenUrl()
     {
-        return 'wp-admin/edit.php?post_type=' . $this->getPostType() . '&orderby=date&order=desc';
+        return self::$wpAdminPath . '/edit.php?post_type=' . $this->getPostType() . '&orderby=date&order=desc';
     }
 
     /**

--- a/plugins/versionpress/tests/End2End/Utils/SeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Utils/SeleniumWorker.php
@@ -66,12 +66,15 @@ class SeleniumWorker implements ITestWorker
     protected static $wpAutomation;
     /** @var TestConfig */
     protected static $testConfig;
+    /** @var string */
+    protected static $wpAdminPath;
 
     protected static $autologin = true;
 
     public function __construct(TestConfig $testConfig)
     {
         self::$testConfig = $testConfig;
+        self::$wpAdminPath = $testConfig->testSite->wpAdminPath;
 
         if (!self::$sharedSession) {
             self::startSession();
@@ -142,7 +145,7 @@ class SeleniumWorker implements ITestWorker
             return;
         }
 
-        $this->url('wp-admin');
+        $this->url(self::$wpAdminPath);
         usleep(100 * 1000); // sometimes we need to wait for the page to fully load
 
         if (!$this->elementExists('#user_login')) {

--- a/plugins/versionpress/tests/End2End/Widgets/WidgetsSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Widgets/WidgetsSeleniumWorker.php
@@ -9,7 +9,7 @@ class WidgetsTestSeleniumWorker extends SeleniumWorker implements IWidgetsTestWo
 
     public function prepare_createWidget()
     {
-        $this->url('wp-admin/widgets.php');
+        $this->url(self::$wpAdminPath . '/widgets.php');
         $this->jsClick("#widget-list .widget:contains('Calendar') .widget-control-edit");
         $this->waitAfterRedirect();
     }
@@ -23,7 +23,7 @@ class WidgetsTestSeleniumWorker extends SeleniumWorker implements IWidgetsTestWo
 
     public function prepare_editWidget()
     {
-        $this->url('wp-admin/widgets.php');
+        $this->url(self::$wpAdminPath . '/widgets.php');
     }
 
     public function editWidget()
@@ -38,7 +38,7 @@ class WidgetsTestSeleniumWorker extends SeleniumWorker implements IWidgetsTestWo
 
     public function prepare_deleteWidget()
     {
-        $this->url('wp-admin/widgets.php');
+        $this->url(self::$wpAdminPath . '/widgets.php');
     }
 
     public function deleteWidget()

--- a/plugins/versionpress/tests/End2End/Widgets/WidgetsTest.php
+++ b/plugins/versionpress/tests/End2End/Widgets/WidgetsTest.php
@@ -33,24 +33,24 @@ class WidgetsTest extends End2EndTestCase
     {
         self::$worker->prepare_createWidget();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createWidget();
 
-        $commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertNumCommits(1);
 
         if (self::$testConfig->end2endTestType === 'selenium' &&
             WpVersionComparer::compare(self::$testConfig->testSite->wpVersion, '4.4-beta1') >= 0
         ) {
-            $commitAsserter->assertCommitAction('option/edit');
-            $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+            $this->commitAsserter->assertCommitAction('option/edit');
+            $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
         } else {
-            $commitAsserter->assertCommitAction('option/create');
-            $commitAsserter->assertCommitPath('A', '%vpdb%/options/%VPID%.ini');
+            $this->commitAsserter->assertCommitAction('option/create');
+            $this->commitAsserter->assertCommitPath('A', '%vpdb%/options/%VPID%.ini');
         }
 
-        $commitAsserter->assertCountOfAffectedFiles(2);
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertCountOfAffectedFiles(2);
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -63,15 +63,15 @@ class WidgetsTest extends End2EndTestCase
     {
         self::$worker->prepare_createWidget();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->createWidget();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('option/edit');
-        $commitAsserter->assertCountOfAffectedFiles(2);
-        $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('option/edit');
+        $this->commitAsserter->assertCountOfAffectedFiles(2);
+        $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -83,15 +83,15 @@ class WidgetsTest extends End2EndTestCase
     {
         self::$worker->prepare_editWidget();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->editWidget();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('option/edit');
-        $commitAsserter->assertCountOfAffectedFiles(1);
-        $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('option/edit');
+        $this->commitAsserter->assertCountOfAffectedFiles(1);
+        $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 
@@ -103,15 +103,15 @@ class WidgetsTest extends End2EndTestCase
     {
         self::$worker->prepare_deleteWidget();
 
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $this->commitAsserter->reset();
 
         self::$worker->deleteWidget();
 
-        $commitAsserter->assertNumCommits(1);
-        $commitAsserter->assertCommitAction('option/edit');
-        $commitAsserter->assertCountOfAffectedFiles(2);
-        $commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
-        $commitAsserter->assertCleanWorkingDirectory();
+        $this->commitAsserter->assertNumCommits(1);
+        $this->commitAsserter->assertCommitAction('option/edit');
+        $this->commitAsserter->assertCountOfAffectedFiles(2);
+        $this->commitAsserter->assertCommitPath('M', '%vpdb%/options/%VPID%.ini');
+        $this->commitAsserter->assertCleanWorkingDirectory();
         DBAsserter::assertFilesEqualDatabase();
     }
 

--- a/plugins/versionpress/tests/Selenium/ActivationDeactivationTest.php
+++ b/plugins/versionpress/tests/Selenium/ActivationDeactivationTest.php
@@ -34,14 +34,14 @@ class ActivationDeactivationTest extends SeleniumTestCase
     public function completeUninstallationOfUnactivatedPluginRemovesAllFiles()
     {
         self::installVersionPress();
-        $this->url('wp-admin/plugins.php');
+        $this->url(self::$wpAdminPath . '/plugins.php');
         $this->byCssSelector('.delete a[href*=\'versionpress\']')->click();
         $this->byCssSelector('.wrap form:nth-of-type(1) input#submit')->click();
 
         $this->waitForElement('.plugins-php #message.updated');
 
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-includes/wpdb.php.original');
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-content/plugins/versionpress');
+        $this->assertFileNotExists(self::$wpAutomation->getAbspath() . '/wp-includes/wpdb.php.original');
+        $this->assertFileNotExists(self::$wpAutomation->getPluginsDir() . '/versionpress');
         $this->assertFileNotExists(self::$testConfig->testSite->path . '/.git');
     }
 
@@ -67,7 +67,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
      */
     public function nagIsDisplayedOnSubsequentRequests()
     {
-        $this->url('wp-admin/index.php');
+        $this->url(self::$wpAdminPath . '/index.php');
         $this->assertElementExists('.vp-activation-nag');
     }
 
@@ -80,12 +80,12 @@ class ActivationDeactivationTest extends SeleniumTestCase
         $updateConfigArgs = [
             'VERSIONPRESS_GUI',
             'html',
-            'require' => 'wp-content/plugins/versionpress/src/Cli/vp-internal.php'
+            'require' => self::$wpAutomation->getPluginsDir() . '/versionpress/src/Cli/vp-internal.php'
         ];
         self::$wpAutomation->runWpCliCommand('vp-internal', 'update-config', $updateConfigArgs);
 
 
-        $this->url('wp-admin/admin.php?page=versionpress/');
+        $this->url(self::$wpAdminPath . '/admin.php?page=versionpress/');
         $this->assertElementExists('#activate-versionpress-btn');
     }
 
@@ -95,7 +95,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
      */
     public function successfulActivationRedirectsToMainVersionPressTableAndAltersWpdbClass()
     {
-        $wpdbFile = self::$testConfig->testSite->path . '/wp-includes/wp-db.php';
+        $wpdbFile = self::$wpAutomation->getAbspath() . '/wp-includes/wp-db.php';
         $wpdbOriginalFile = $wpdbFile . '.original';
         $this->assertFileNotExists($wpdbOriginalFile);
         $hashBeforeInit = md5_file($wpdbFile);
@@ -153,7 +153,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
      */
     public function deactivateShowsConfirmationScreen()
     {
-        $this->url('wp-admin/plugins.php');
+        $this->url(self::$wpAdminPath . '/plugins.php');
         $this->byCssSelector('.deactivate a[href*=\'versionpress\']')->click();
 
 
@@ -176,7 +176,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
         $this->byCssSelector('#cancel_deactivation')->click();
 
         $this->assertContains('wp-admin/plugins.php', $this->url());
-        $this->assertFileExists(self::$testConfig->testSite->path . '/wp-content/vpdb/.active');
+        $this->assertFileExists(self::$wpAutomation->getVpdbDir() . '/.active');
 
     }
 
@@ -200,7 +200,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
         $this->byCssSelector('#confirm_deactivation')->click();
         $this->assertContains('wp-admin/plugins.php', $this->url());
 
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-includes/wpdb.php.original');
+        $this->assertFileNotExists(self::$wpAutomation->getAbspath() . '/wp-includes/wpdb.php.original');
         $this->assertFileExists(self::$testConfig->testSite->path . '/.git');
 
     }
@@ -231,9 +231,9 @@ class ActivationDeactivationTest extends SeleniumTestCase
 
         $this->waitForElement('.plugins-php #message.updated');
 
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-includes/wpdb.php.original');
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-content/plugins/versionpress');
-        $this->assertFileNotExists(self::$testConfig->testSite->path . '/wp-content/vpdb');
+        $this->assertFileNotExists(self::$wpAutomation->getAbspath() . '/wp-includes/wpdb.php.original');
+        $this->assertFileNotExists(self::$wpAutomation->getPluginsDir() . '/versionpress');
+        $this->assertFileNotExists(self::$wpAutomation->getVpdbDir());
         $this->assertFileNotExists(self::$testConfig->testSite->path . '/.git');
 
     }
@@ -245,7 +245,7 @@ class ActivationDeactivationTest extends SeleniumTestCase
 
     private function activateVersionPress()
     {
-        $this->url('wp-admin/plugins.php');
+        $this->url(self::$wpAdminPath . '/plugins.php');
         $this->byCssSelector('.activate a[href*=\'versionpress\']')->click();
         $this->waitAfterRedirect();
     }

--- a/plugins/versionpress/tests/Selenium/PublicWebTest.php
+++ b/plugins/versionpress/tests/Selenium/PublicWebTest.php
@@ -3,6 +3,7 @@
 namespace VersionPress\Tests\Selenium;
 
 use VersionPress\Tests\Utils\CommitAsserter;
+use VersionPress\Utils\PathUtils;
 
 class PublicWebTest extends SeleniumTestCase
 {
@@ -51,7 +52,9 @@ class PublicWebTest extends SeleniumTestCase
      */
     public function commentCanBeAdded()
     {
-        $commitAsserter = new CommitAsserter($this->gitRepository);
+        $vpdbPath = self::$wpAutomation->getVpdbDir();
+        $relativePathToVpdb = PathUtils::getRelativePath(self::$testConfig->testSite->path, $vpdbPath);
+        $commitAsserter = new CommitAsserter($this->gitRepository, ['vpdb' => $relativePathToVpdb]);
 
         $this->url('?p=' . self::$testPostId);
 

--- a/plugins/versionpress/tests/Selenium/SecurityTest.php
+++ b/plugins/versionpress/tests/Selenium/SecurityTest.php
@@ -2,17 +2,22 @@
 
 namespace VersionPress\Tests\Selenium;
 
+use VersionPress\Tests\Automation\WpAutomation;
 use VersionPress\Tests\End2End\Utils\HttpStatusCodeUtil;
 use VersionPress\Tests\Utils\TestConfig;
+use VersionPress\Utils\PathUtils;
 
 class SecurityTest extends \PHPUnit_Framework_TestCase
 {
-
+    /** @var TestConfig */
     private static $testConfig;
+    /** @var WpAutomation */
+    private static $wpAutomation;
 
     public function __construct()
     {
         self::$testConfig = TestConfig::createDefaultConfig();
+        self::$wpAutomation = new WpAutomation(self::$testConfig->testSite, self::$testConfig->wpCliVersion);
     }
 
     /**
@@ -22,7 +27,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
     {
         $url = self::$testConfig->testSite->url . "/.git/config";
         $statusCode = HttpStatusCodeUtil::getStatusCode($url);
-        $this->assertEquals(403, $statusCode, "Wrong HTTP status codes");
+        $this->assertTrue($statusCode === 403 || $statusCode === 404, "Wrong HTTP status code ($statusCode)");
     }
 
     /**
@@ -30,9 +35,11 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
      */
     public function vpdbDoesntAllowDirectAccess()
     {
-        $url = self::$testConfig->testSite->url . "/wp-content/vpdb/web.config";
+        $vpdbDir = self::$wpAutomation->getVpdbDir();
+        $relativePathToVpdb = PathUtils::getRelativePath(self::$wpAutomation->getWebRoot(), $vpdbDir);
+        $url = self::$testConfig->testSite->url . '/' . $relativePathToVpdb . "/web.config";
         $statusCode = HttpStatusCodeUtil::getStatusCode($url);
-        $this->assertEquals(403, $statusCode, "Wrong HTTP status codes");
+        $this->assertTrue($statusCode === 403 || $statusCode === 404, "Wrong HTTP status code ($statusCode)");
     }
 
     /**
@@ -40,8 +47,11 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
      */
     public function vpconfigDoesntAllowDirectAccess()
     {
-        $url = self::$testConfig->testSite->url . "/wp-content/plugins/versionpress/vpconfig.yml";
+        $pluginsDir = self::$wpAutomation->getPluginsDir();
+        $relativePathToPluginsDir = PathUtils::getRelativePath(self::$wpAutomation->getWebRoot(), $pluginsDir);
+
+        $url = self::$testConfig->testSite->url . '/' . $relativePathToPluginsDir . "/versionpress/vpconfig.yml";
         $statusCode = HttpStatusCodeUtil::getStatusCode($url);
-        $this->assertEquals(403, $statusCode, "Wrong HTTP status codes");
+        $this->assertTrue($statusCode === 403 || $statusCode === 404, "Wrong HTTP status code ($statusCode)");
     }
 }

--- a/plugins/versionpress/tests/Selenium/SeleniumTestCase.php
+++ b/plugins/versionpress/tests/Selenium/SeleniumTestCase.php
@@ -24,6 +24,11 @@ abstract class SeleniumTestCase extends PHPUnit_Extensions_Selenium2TestCase
      */
     protected static $wpAutomation;
 
+    /**
+     * @var string
+     */
+    protected static $wpAdminPath;
+
 
     /**
      * If true, {@link loginIfNecessary} is called on {@link setUpSite}.
@@ -71,6 +76,7 @@ abstract class SeleniumTestCase extends PHPUnit_Extensions_Selenium2TestCase
 
         if (!self::$testConfig) {
             self::$testConfig = TestConfig::createDefaultConfig();
+            self::$wpAdminPath = self::$testConfig->testSite->wpAdminPath;
         }
 
         if (!self::$wpAutomation) {
@@ -121,7 +127,7 @@ abstract class SeleniumTestCase extends PHPUnit_Extensions_Selenium2TestCase
             return;
         }
 
-        $this->url('wp-admin');
+        $this->url(self::$wpAdminPath);
         usleep(100 * 1000); // sometimes we need to wait for the page to fully load
 
         if (!$this->elementExists('#user_login')) {
@@ -136,7 +142,7 @@ abstract class SeleniumTestCase extends PHPUnit_Extensions_Selenium2TestCase
 
     protected function logOut()
     {
-        $this->url('wp-login.php?action=logout');
+        $this->url(dirname(self::$wpAdminPath) . '/wp-login.php?action=logout');
         $this->byCssSelector('body>p>a')->click();
         $this->waitAfterRedirect();
     }

--- a/plugins/versionpress/tests/Selenium/ThemeCustomizerTest.php
+++ b/plugins/versionpress/tests/Selenium/ThemeCustomizerTest.php
@@ -12,7 +12,7 @@ class ThemeCustomizerTest extends SeleniumTestCase
      */
     public function everyChangeMadeInCustomizerCreatesThemeCustomizeAction()
     {
-        $this->url('wp-admin/customize.php');
+        $this->url(self::$wpAdminPath . '/customize.php');
         $this->byCssSelector('#accordion-section-title_tagline .accordion-section-title')->click();
         $this->setValue('#customize-control-blogname input', 'Some name');
         $this->byId('save')->click();

--- a/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
+++ b/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
@@ -32,11 +32,14 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
     protected static $shortcodesReplacer;
     /** @var VpidRepository */
     protected static $vpidRepository;
+    /** @var WpAutomation */
+    private static $wpAutomation;
 
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
         self::$testConfig = TestConfig::createDefaultConfig();
+        self::$wpAutomation = new WpAutomation(self::$testConfig->testSite, self::$testConfig->wpCliVersion);
 
         self::setUpSite();
         DBAsserter::assertFilesEqualDatabase();
@@ -46,10 +49,10 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
         $shortcodeFile = dirname($schemaReflection->getFileName()) . '/wordpress-shortcodes.yml';
 
         /** @var $wp_db_version */
-        require(self::$testConfig->testSite->path . '/wp-includes/version.php');
+        require(self::$wpAutomation->getAbspath() . '/wp-includes/version.php');
 
         if (!function_exists('get_shortcode_regex')) {
-            require_once(self::$testConfig->testSite->path . '/wp-includes/shortcodes.php');
+            require_once(self::$wpAutomation->getAbspath() . '/wp-includes/shortcodes.php');
         }
 
         self::$schemaInfo = new DbSchemaInfo($schemaFile, self::$testConfig->testSite->dbTablePrefix, $wp_db_version);
@@ -66,20 +69,19 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
         self::$vpidRepository = new VpidRepository(self::$database, self::$schemaInfo);
         self::$shortcodesReplacer = new ShortcodesReplacer($shortcodesInfo, self::$vpidRepository);
 
-        $vpdbPath = self::$testConfig->testSite->path . '/wp-content/vpdb';
+        $vpdbPath = self::$wpAutomation->getVpdbDir();
         self::$storageFactory = new StorageFactory($vpdbPath, self::$schemaInfo, self::$database, []);
         self::$urlReplacer = new AbsoluteUrlReplacer(self::$testConfig->testSite->url);
     }
 
     private static function setUpSite()
     {
-        $wpAutomation = new WpAutomation(self::$testConfig->testSite, self::$testConfig->wpCliVersion);
-        if (!$wpAutomation->isSiteSetUp()) {
-            $wpAutomation->setUpSite();
+        if (!self::$wpAutomation->isSiteSetUp()) {
+            self::$wpAutomation->setUpSite();
         }
-        if (!$wpAutomation->isVersionPressInitialized()) {
-            $wpAutomation->copyVersionPressFiles();
-            $wpAutomation->initializeVersionPress();
+        if (!self::$wpAutomation->isVersionPressInitialized()) {
+            self::$wpAutomation->copyVersionPressFiles();
+            self::$wpAutomation->initializeVersionPress();
         }
     }
 

--- a/plugins/versionpress/tests/Utils/SiteConfig.php
+++ b/plugins/versionpress/tests/Utils/SiteConfig.php
@@ -86,6 +86,11 @@ class SiteConfig
     public $url;
 
     /**
+     * @var string
+     */
+    public $wpAdminPath = 'wp-admin';
+
+    /**
      * Site title
      *
      * @var string

--- a/plugins/versionpress/tests/Utils/SiteConfig.php
+++ b/plugins/versionpress/tests/Utils/SiteConfig.php
@@ -26,6 +26,14 @@ class SiteConfig
      */
     public $host;
 
+    /**
+     * Type of site - standard WP structure, Composer-based etc.
+     * Possible values: standard / composer
+     *
+     * @var string
+     */
+    public $installationType = 'standard';
+
 
     //----------------------
     // DB config

--- a/plugins/versionpress/tests/Utils/TestConfig.php
+++ b/plugins/versionpress/tests/Utils/TestConfig.php
@@ -76,6 +76,7 @@ class TestConfig
             // WP site config
             $this->sites[$siteId]->path = $rawSiteConfig['wp-site']['path'];
             $this->sites[$siteId]->url = $rawSiteConfig['wp-site']['url'];
+            $this->sites[$siteId]->wpAdminPath = $rawSiteConfig['wp-site']['wp-admin-path'];
             $this->sites[$siteId]->title = $rawSiteConfig['wp-site']['title'];
             $this->sites[$siteId]->adminName = $rawSiteConfig['wp-site']['admin-name'];
             $this->sites[$siteId]->adminPassword = $rawSiteConfig['wp-site']['admin-pass'];

--- a/plugins/versionpress/tests/Utils/TestConfig.php
+++ b/plugins/versionpress/tests/Utils/TestConfig.php
@@ -64,6 +64,7 @@ class TestConfig
             // General settings
             $this->sites[$siteId]->name = $siteId;
             $this->sites[$siteId]->host = $rawSiteConfig['host'];
+            $this->sites[$siteId]->installationType = $rawSiteConfig['installation-type'];
 
             // DB config
             $this->sites[$siteId]->dbHost = $rawSiteConfig['db']['host'];

--- a/plugins/versionpress/tests/test-config.sample.yml
+++ b/plugins/versionpress/tests/test-config.sample.yml
@@ -41,6 +41,7 @@ sites:
     wp-site:
       path: /Users/johdoe/Sites/vp01
       url: http://localhost/vp01
+      wp-admin-path: wp-admin
       title: "VersionPress test @ localhost"
 
   vp01-composer:
@@ -54,4 +55,5 @@ sites:
     wp-site:
       path: /Users/johdoe/Sites/vp01
       url: http://localhost/vp01/web # Note that the site runs from subdirectory
+      wp-admin-path: wp/wp-admin
       title: "VersionPress test @ localhost"

--- a/plugins/versionpress/tests/test-config.sample.yml
+++ b/plugins/versionpress/tests/test-config.sample.yml
@@ -28,9 +28,10 @@ wp-cli-version: 0.23.0
 # Configured sites
 sites:
 
-  # Local sites
+  # Standard site
   vp01:
     host: localhost
+    installation-type: standard
     db:
       # Database should be created. VersionPress does not create it
       host: 127.0.0.1
@@ -40,4 +41,17 @@ sites:
     wp-site:
       path: /Users/johdoe/Sites/vp01
       url: http://localhost/vp01
+      title: "VersionPress test @ localhost"
+
+  vp01-composer:
+    host: localhost
+    installation-type: composer
+    db:
+      host: 127.0.0.1
+      dbname: vp01
+      user: vp01
+      password: vp01
+    wp-site:
+      path: /Users/johdoe/Sites/vp01
+      url: http://localhost/vp01/web # Note that the site runs from subdirectory
       title: "VersionPress test @ localhost"


### PR DESCRIPTION
Resolves #1037.

VersionPress now works with Composer!

## Highlights of this PR
### Tracking chages in `composer.json`
VersionPress now tracks installation / uninstallation / update of Composer packages using [Composer scripts](https://getcomposer.org/doc/articles/scripts.md). There are two scripts:
- `pre-update-cmd` calls `wp vp-composer prepare-for-composer-changes`. This command saves list of plugins and themes installed before Composer changes files into transient option.
- `post-update-cmd`calls `wp vp-composer commit-composer-changes`. This command creates according `ChangeInfo` objects and does the commit.

### Installing correct dependencies after VP actions
VersionPress now calls `composer install` after:
- undo / rollback
- clone
- push / pull
- restore-site

### Support of Composer-based site in `test-config.yml`
`SiteConfig` now contains `type` to define standard / composer-based site.  `WpAutomation::runAutomation` then installs standard WP site using WP-CLI or [Pedestal-based](https://github.com/versionpress/pedestal) site using `composer create-project`.

### Several fixes in tests
It was necessary to adjust the tests to work with this different approach. For example, there were often hardcoded paths like `wp-content/vpdb`, `wp-includes` etc.

Reviewers:
- [x] @octopuss 
- [ ] @borekb 