### PR TITLE
Use `classnames` library for complex class names

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   "license": "GPL",
   "dependencies": {
     "autoprefixer-loader": "3.2.0",
+    "classnames": "2.2.5",
     "core-js": "2.3.0",
     "css-loader": "0.23.1",
     "diff": "2.2.2",

--- a/frontend/src/BulkActionPanel/BulkActionPanel.react.tsx
+++ b/frontend/src/BulkActionPanel/BulkActionPanel.react.tsx
@@ -1,6 +1,8 @@
+
 /// <reference path='../Commits/Commits.d.ts' />
 
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import './BulkActionPanel.less';
 
@@ -31,6 +33,11 @@ export default class BulkActionPanel extends React.Component<BulkActionPanelProp
   render() {
     const { selectedCommits, enableActions } = this.props;
 
+    const noteClassName = classNames({
+      'BulkActionPanel-note': true,
+      'hide': selectedCommits.length === 0
+    });
+
     return (
       <div className='BulkActionPanel'>
         <div className='alignleft actions bulkactions'>
@@ -47,7 +54,7 @@ export default class BulkActionPanel extends React.Component<BulkActionPanelProp
             onClick={this.onBulkAction.bind(this)}
             disabled={!enableActions || selectedCommits.length === 0}
           />
-          <div className={'BulkActionPanel-note' + (selectedCommits.length === 0 ? ' hide' : '')}>
+          <div className={noteClassName}>
             ({selectedCommits.length} {selectedCommits.length === 1 ? 'change' : 'changes'} selected;{' '}
             <a className='BulkActionPanel-clear' href='#' onClick={this.onClearSelection.bind(this)}>clear selection</a>
             )

--- a/frontend/src/CommitPanel/CommitPanel.react.tsx
+++ b/frontend/src/CommitPanel/CommitPanel.react.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import CommitPanelCommit from './CommitPanelCommit.react';
 import CommitPanelNotice from './CommitPanelNotice.react';
@@ -33,16 +34,21 @@ export default class CommitPanel extends React.Component<CommitPanelProps, Commi
   }
 
   render() {
-    const className = 'CommitPanel-notice' + (this.state.detailsLevel !== 'none' ? ' CommitPanel-notice--expanded' : '');
+    const { detailsLevel } = this.state;
+
+    const noticeClassName = classNames({
+      'CommitPanel-notice': true,
+      'CommitPanel-notice--expanded': detailsLevel !== 'none'
+    });
 
     return (
       <div className='CommitPanel'>
-        <div className={className}>
+        <div className={noticeClassName}>
           <CommitPanelNotice
-            onDetailsLevelChanged={detailsLevel => this.changeDetailsLevel(detailsLevel)}
-            detailsLevel={this.state.detailsLevel}
+            onDetailsLevelChanged={newDetailsLevel => this.changeDetailsLevel(newDetailsLevel)}
+            detailsLevel={detailsLevel}
           />
-          {this.state.detailsLevel !== 'none'
+          {detailsLevel !== 'none'
             ? <CommitPanelCommit
                 onCommit={this.props.onCommit}
                 onDiscard={this.props.onDiscard}
@@ -68,13 +74,16 @@ export default class CommitPanel extends React.Component<CommitPanelProps, Commi
       return null;
     }
 
-    const className = 'CommitPanel-details' + (this.state.isLoading ? ' loading' : '');
+    const detailsClassName = classNames({
+      'CommitPanel-details': true,
+      'loading': this.state.isLoading
+    });
     const content = this.state.detailsLevel === 'overview'
       ? <CommitPanelOverview gitStatus={this.state.gitStatus} />
       : <CommitPanelDetails diff={this.state.diff} />;
 
     return (
-      <div className={className}>
+      <div className={detailsClassName}>
         {this.renderToggle()}
         {this.state.isLoading
           ? <div className='CommitPanel-details-loader'></div>

--- a/frontend/src/Commits/CommitsTableRowDetails.react.tsx
+++ b/frontend/src/Commits/CommitsTableRowDetails.react.tsx
@@ -1,6 +1,7 @@
 /// <reference path='./Commits.d.ts' />
 
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import CommitOverview from './CommitOverview.react';
 import DiffPanel from './DiffPanel.react';
@@ -15,43 +16,48 @@ interface CommitsTableRowDetailsProps extends React.Props<JSX.Element> {
 export default class CommitsTableRowDetails extends React.Component<CommitsTableRowDetailsProps, {}> {
 
   render() {
-    if (this.props.commit === null || this.props.detailsLevel === 'none') {
+    const { commit, detailsLevel, isLoading, diff } = this.props;
+
+    if (commit === null || detailsLevel === 'none') {
       return <tr />;
     }
-    const commit = this.props.commit;
-    const className = 'details-row' + (commit.isEnabled ? '' : 'disabled') + (this.props.isLoading ? ' loading' : '');
-    const detailsClass = 'details';
 
-    const overview = <CommitOverview commit={commit} />;
+    const rowClassName = classNames({
+      'details-row': true,
+      'disabled': !commit.isEnabled,
+      'loading': isLoading
+    });
 
     const overviewRow = (
-      <tr className={className}>
+      <tr className={rowClassName}>
         <td />
         <td />
         <td />
         <td />
         <td>
-          {this.props.isLoading
+          {isLoading
             ? <div className='details-row-loader'/>
             : null
           }
-          <div className={detailsClass}>{overview}</div>
+          <div className='details'>
+            <CommitOverview commit={commit} />
+          </div>
         </td>
         <td />
       </tr>
     );
 
     const fullDiffRow = (
-      <tr className={className}>
+      <tr className={rowClassName}>
         <td colSpan={6}>
-          <div className={detailsClass}>
-            <DiffPanel diff={this.props.diff} />
+          <div className='details'>
+            <DiffPanel diff={diff} />
           </div>
         </td>
       </tr>
     );
 
-    return this.props.detailsLevel === 'overview' ? overviewRow : fullDiffRow;
+    return detailsLevel === 'overview' ? overviewRow : fullDiffRow;
   }
 
 }

--- a/frontend/src/Commits/CommitsTableRowSummary.react.tsx
+++ b/frontend/src/Commits/CommitsTableRowSummary.react.tsx
@@ -31,12 +31,10 @@ export default class CommitsTableRowSummary extends React.Component<CommitsTable
       'disabled': !commit.isEnabled,
       'displayed-details': detailsLevel !== 'none'
     });
-
     const undoClassName = classNames({
       'vp-table-undo': true,
       'disabled': commit.isMerge || !enableActions
     });
-
     const rollbackClassName = classNames({
       'vp-table-rollback': true,
       'disabled': !enableActions

--- a/frontend/src/ServicePanel/ServicePanel.react.tsx
+++ b/frontend/src/ServicePanel/ServicePanel.react.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import config from '../config';
 
 import './ServicePanel.less';
@@ -10,11 +11,14 @@ interface ServicePanelProps extends React.Props<JSX.Element> {
 export default class ServicePanel extends React.Component<ServicePanelProps, {}> {
 
   render() {
-    const className = 'ServicePanel-wrapper' + (this.props.isVisible ? '' : ' ServicePanel-wrapper--hide');
+    const wrapperClassName = classNames({
+      'ServicePanel-wrapper': true,
+      'ServicePanel-wrapper--hide': !this.props.isVisible
+    });
     const systemInfoUrl = config.api.adminUrl + '/admin.php?page=versionpress/admin/system-info.php';
 
     return (
-      <div className={className}>
+      <div className={wrapperClassName}>
         <div className='ServicePanel welcome-panel'>
           <div className='ServicePanel-inner'>
             <p className='ServicePanel-warning'>

--- a/frontend/src/common/FlashMessage.react.tsx
+++ b/frontend/src/common/FlashMessage.react.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import './FlashMessage.less';
 
@@ -16,28 +17,38 @@ export default class FlashMessage extends React.Component<FlashMessageProps, Fla
 
   constructor() {
     super();
-    this.state = { showDetails: false };
+    this.state = {
+      showDetails: false
+    };
   }
 
   render() {
-    if (this.props.code === null) {
+    const { code, message, details } = this.props;
+    const { showDetails } = this.state;
+
+    if (code === null) {
       return null;
     }
 
+    const linkClassName = classNames({
+      'FlashMessage-detailsLink-displayed': showDetails,
+      'FlashMessage-detailsLink-hidden': !showDetails
+    });
+
     return (
-      <div className={this.props.code}>
+      <div className={code}>
         <p>
-          {this.props.message} {' '}
-          {this.props.details
+          {message} {' '}
+          {details
             ? <a
-                className={'FlashMessage-detailsLink' + (this.state.showDetails ? '-displayed' : '-hidden')}
+                className={linkClassName}
                 href='#'
                 onClick={this.toggleDetails.bind(this)}
               >Details </a>
             : null}
         </p>
-        {this.props.details && this.state.showDetails
-          ? <p className='FlashMessage-details'>{this.props.details.toString()}</p>
+        {details && showDetails
+          ? <p className='FlashMessage-details'>{details.toString()}</p>
           : null}
       </div>
     );
@@ -45,7 +56,9 @@ export default class FlashMessage extends React.Component<FlashMessageProps, Fla
 
   toggleDetails(e: React.MouseEvent) {
     e.preventDefault();
-    this.setState({ showDetails: !this.state.showDetails });
+    this.setState({
+      showDetails: !this.state.showDetails
+    });
   }
 
 }

--- a/frontend/src/common/ProgressBar.react.tsx
+++ b/frontend/src/common/ProgressBar.react.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import './ProgressBar.less';
 
@@ -32,10 +33,15 @@ export default class ProgressBar extends React.Component<React.Props<JSX.Element
       display: (isVisible ? 'inline-block' : 'none'),
     };
 
+    const spinnerClassName = classNames({
+      'ProgressBar-spinner': true,
+      'hide': !isVisible
+    });
+
     return (
       <div className='ProgressBar'>
         <div className='ProgressBar-bar' style={styles}>
-          <div className={'ProgressBar-spinner' + (isVisible ? '' : ' hide')}></div>
+          <div className={spinnerClassName}></div>
           <div className='ProgressBar-spinner-icon'></div>
         </div>
       </div>

--- a/frontend/src/pages/HomePage.react.tsx
+++ b/frontend/src/pages/HomePage.react.tsx
@@ -5,6 +5,7 @@ import * as ReactRouter from 'react-router';
 import * as request from 'superagent';
 import * as moment from 'moment';
 import * as Promise from 'core-js/es6/promise';
+import * as classNames from 'classnames';
 import update = require('react-addons-update');
 import BulkActionPanel from '../BulkActionPanel/BulkActionPanel.react';
 import CommitPanel from '../CommitPanel/CommitPanel.react';
@@ -443,8 +444,12 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
   render() {
     const enableActions = !this.state.isDirtyWorkingDirectory;
 
+    const homePageClassName = classNames({
+      'loading': this.state.isLoading
+    });
+
     return (
-      <div className={this.state.isLoading ? 'loading' : ''}>
+      <div className={homePageClassName}>
         <ProgressBar ref='progress' />
         <ServicePanelButton onClick={this.toggleServicePanel.bind(this)} />
         <h1 className='vp-header'>VersionPress</h1>

--- a/frontend/typings.json
+++ b/frontend/typings.json
@@ -3,6 +3,7 @@
   "env": "browser",
   "version": false,
   "ambientDependencies": {
+    "classnames": "registry:dt/classnames#0.0.0+20160316155526",
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "diff": "registry:dt/diff#0.0.0+20160318080727",
     "moment": "registry:dt/moment#2.8.0+20160316155526",


### PR DESCRIPTION
Resolves #1089.

Introduced [classnames](https://github.com/JedWatson/classnames) library to the front end codebase and improved readability and clarity of finding a string for the JSX attribute **className**.

Since @vasek17 is on vacation, I didn't include him as a reviewer of this PR.
Reviewers:

- [x] @JanVoracek 