### PR TITLE
Improved git verification on system info

### DIFF
--- a/plugins/versionpress/src/Utils/SystemInfo.php
+++ b/plugins/versionpress/src/Utils/SystemInfo.php
@@ -46,7 +46,7 @@ class SystemInfo
         $process->run();
 
         $info['git-binary-as-configured'] = $gitBinary;
-        $info['git-available'] = $process->getErrorOutput() === null;
+        $info['git-available'] = $process->getErrorOutput() === null || !strlen($process->getErrorOutput());
 
         if ($info['git-available'] === false) {
             $info['output'] = [


### PR DESCRIPTION
When executing GIT version check , the $process->getOutput() output would be correct _'git version 1.9.1'_ and $process->getErrorOutput() output would be **an empty string**, since no error was present. Currently it only verifies for NULL outputs, so the empty string would fail. 

BEFORE the fix : 
```
array (
  'git-binary-as-configured' => 'git',
  'git-available' => false,
  'output' => 
  array (
    'stdout' => 'git version 1.9.1',
    'stderr' => '',
  ),
  'env-path' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
)


```
AFTER the fix: 
```
array (
  'git-binary-as-configured' => 'git',
  'git-available' => true,
  'git-version' => '1.9.1',
  'git-binary-as-called-by-vp' => 'git',
  'git-full-path' => '/usr/bin/git
',
  'versionpress-min-required-version' => '1.9',
  'matches-min-required-version' => true,
)

```
Reviewers:

- [x] @JanVoracek
