### PR TITLE
Fix for DB password with regex characters on initial clone.

### DIFF
--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -80,12 +80,12 @@ class WpConfigEditor
     {
         $wpConfigContent = file_get_contents($this->wpConfigPath);
 
-        $phpizedValue = $usePlainValue ? $value : var_export($value, true);
+        $phpizedValue = preg_quote($usePlainValue ? $value : var_export($value, true), '/');
 
         $configContainsDefinition = preg_match($replaceRegex, $wpConfigContent);
 
         if ($configContainsDefinition) {
-            $wpConfigContent = preg_replace(preg_quote($replaceRegex), "\${1}$phpizedValue\${2}", $wpConfigContent);
+            $wpConfigContent = preg_replace($replaceRegex, "\${1}$phpizedValue\${2}", $wpConfigContent);
         } else {
             $originalContent = $wpConfigContent;
             $endOfEditableSection = $this->isCommonConfig ?

--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -85,7 +85,7 @@ class WpConfigEditor
         $configContainsDefinition = preg_match($replaceRegex, $wpConfigContent);
 
         if ($configContainsDefinition) {
-            $wpConfigContent = preg_replace($replaceRegex, "\${1}$phpizedValue\${2}", $wpConfigContent);
+            $wpConfigContent = preg_replace(preg_quote($replaceRegex), "\${1}$phpizedValue\${2}", $wpConfigContent);
         } else {
             $originalContent = $wpConfigContent;
             $endOfEditableSection = $this->isCommonConfig ?

--- a/plugins/versionpress/tests/Unit/WpConfigEditorTest.php
+++ b/plugins/versionpress/tests/Unit/WpConfigEditorTest.php
@@ -235,6 +235,21 @@ class WpConfigEditorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
     }
 
+    /**
+     * @test
+     */
+    public function editorSavesValueWithRegexReferenceCorrectly()
+    {
+        file_put_contents($this->commonConfigPath, "<?php\ndefine('TEST', 'value');\n");
+
+        $a = new WpConfigEditor($this->commonConfigPath, true);
+        $a->updateConfigConstant('TEST', 'value with regex reference $1');
+
+        $expectedContent = "<?php\ndefine('TEST', 'value with regex reference $1');\n";
+
+        $this->assertEquals($expectedContent, file_get_contents($this->commonConfigPath));
+    }
+
 // ---------- wp-config.php ------------
 
     /**


### PR DESCRIPTION
Resolves #1107.

Here's a fix for the issue I opened with DB password that had regex characters in them not getting copied properly on initial clone.

Reviewers:
- [x] @JanVoracek 
