### PR TITLE
Integration of autocomplete and commit history visualisation

### DIFF
--- a/frontend/src/actions/commits.ts
+++ b/frontend/src/actions/commits.ts
@@ -46,6 +46,10 @@ export function fetchCommits (page: number | string = appStore.page) {
           commitsTableStore.reset();
           servicePanelStore.setMessage(getErrorMessage(res, err));
         } else {
+          navigationStore.activeQuery = navigationStore.query;
+          if (navigationStore.activeQuery !== '' && commitsTableStore.showVisualisation) {
+            commitsTableStore.toggleShowVisualisation(false);
+          }
           commitsTableStore.setPages(data.pages.map(c => c + 1));
           commitsTableStore.setCommitRows(data.commits.map(commit => (
             new CommitRow(commit, indexOf(appStore.selectedCommits, commit) !== -1))

--- a/frontend/src/actions/update.ts
+++ b/frontend/src/actions/update.ts
@@ -15,7 +15,7 @@ export function checkUpdate() {
   WpApi
     .get('should-update')
     .query({
-      query: encodeURIComponent(navigationStore.query),
+      query: encodeURIComponent(navigationStore.activeQuery),
       latestCommit: commits[0].hash,
     })
     .end((err: any, res: request.Response) => {

--- a/frontend/src/components/commits-table/CommitsTable.tsx
+++ b/frontend/src/components/commits-table/CommitsTable.tsx
@@ -16,6 +16,7 @@ import { findIndex } from '../../utils/ArrayUtils';
 import CommitRow from '../../entities/CommitRow';
 import { AppStore } from '../../stores/appStore';
 import { CommitsTableStore } from '../../stores/commitsTableStore';
+import { NavigationStore } from '../../stores/navigationStore';
 import { LoadingStore } from '../../stores/loadingStore';
 
 import './CommitsTable.less';
@@ -23,10 +24,11 @@ import './CommitsTable.less';
 interface CommitsTableProps {
   appStore?: AppStore;
   commitsTableStore?: CommitsTableStore;
+  navigationStore?: NavigationStore;
   loadingStore?: LoadingStore;
 }
 
-@observer(['appStore', 'commitsTableStore', 'loadingStore'])
+@observer(['appStore', 'commitsTableStore', 'navigationStore', 'loadingStore'])
 export default class CommitsTable extends React.Component<CommitsTableProps, {}> {
 
   onSelectAllChange = (isChecked: boolean) => {
@@ -66,7 +68,7 @@ export default class CommitsTable extends React.Component<CommitsTableProps, {}>
         onUndo={this.onUndo}
         onRollback={this.onRollback}
         onCommitsSelect={this.onCommitsSelect}
-        onChangeShowVisualisation={commitsTableStore.changeShowVisualisation}
+        onToggleShowVisualisation={commitsTableStore.toggleShowVisualisation}
         key={commitRow.commit.hash}
       />
     );
@@ -84,7 +86,7 @@ export default class CommitsTable extends React.Component<CommitsTableProps, {}>
   };
 
   render() {
-    const { appStore, commitsTableStore, loadingStore } = this.props;
+    const { appStore, commitsTableStore, navigationStore, loadingStore } = this.props;
     const { enableActions } = appStore;
     const {
       pages,
@@ -94,7 +96,7 @@ export default class CommitsTable extends React.Component<CommitsTableProps, {}>
       selectableCommits,
       areAllCommitsSelected,
       branches,
-      changeShowVisualisation,
+      toggleShowVisualisation,
     } = commitsTableStore;
     const { isLoading } = loadingStore;
 
@@ -115,10 +117,11 @@ export default class CommitsTable extends React.Component<CommitsTableProps, {}>
           areAllCommitsSelected={areAllCommitsSelected}
           selectableCommitsCount={selectableCommits.length}
           enableActions={enableActions}
+          canToggleVisualisation={navigationStore.activeQuery === ''}
           showVisualisation={showVisualisation}
           branches={branches}
           onSelectAllChange={this.onSelectAllChange}
-          onChangeShowVisualisation={changeShowVisualisation}
+          onToggleShowVisualisation={toggleShowVisualisation}
         />
         {commitRows.map((commitRow: CommitRow, index: number) => (
           this.renderRow(commitRow, index === notAbleNoteIndex)

--- a/frontend/src/components/commits-table/commit-summary/CommitSummary.tsx
+++ b/frontend/src/components/commits-table/commit-summary/CommitSummary.tsx
@@ -26,7 +26,7 @@ interface CommitSummaryProps {
   onRollback(hash: string, date: string): void;
   onCommitsSelect(commits: Commit[], isChecked: boolean, isShiftKey: boolean): void;
   onDetailsLevelChange(detailsLevel: DetailsLevel): void;
-  onChangeShowVisualisation(): void;
+  onToggleShowVisualisation(): void;
 }
 
 @observer
@@ -109,7 +109,7 @@ export default class CommitSummary extends React.Component<CommitSummaryProps, {
       detailsLevel,
       showVisualisation,
       visualisation,
-      onChangeShowVisualisation,
+      onToggleShowVisualisation,
     } = this.props;
 
     if (commit === null) {
@@ -127,7 +127,7 @@ export default class CommitSummary extends React.Component<CommitSummaryProps, {
           environment={commit.environment}
           showVisualisation={showVisualisation}
           visualisation={visualisation}
-          onChangeShowVisualisation={onChangeShowVisualisation}
+          onToggleShowVisualisation={onToggleShowVisualisation}
         />
         <Checkbox
           isVisible={commit.canUndo}

--- a/frontend/src/components/commits-table/environment/Environment.tsx
+++ b/frontend/src/components/commits-table/environment/Environment.tsx
@@ -10,7 +10,7 @@ interface EnvironmentProps {
   environment: string;
   showVisualisation: boolean;
   visualisation: Visualisation;
-  onChangeShowVisualisation(): void;
+  onToggleShowVisualisation(): void;
 }
 
 const LEFT = 10;
@@ -29,11 +29,11 @@ export default class Environment extends React.Component<EnvironmentProps, {}> {
     window.addEventListener('resize', () => this.forceUpdate());
   }
 
-  onChangeShowVisualisation = (e: React.MouseEvent) => {
+  onToggleShowVisualisation = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
-    this.props.onChangeShowVisualisation();
+    this.props.onToggleShowVisualisation();
   };
 
   render() {
@@ -52,7 +52,7 @@ export default class Environment extends React.Component<EnvironmentProps, {}> {
         {(!showVisualisation && environment !== '?') &&
           <ColorInfo
             environment={environment}
-            onClick={this.onChangeShowVisualisation}
+            onClick={this.onToggleShowVisualisation}
           />
         }
         {showVisualisation &&
@@ -64,7 +64,7 @@ export default class Environment extends React.Component<EnvironmentProps, {}> {
             strokeWidth={STROKE_WIDTH}
             dotRadius={DOT_RADIUS}
             visualisation={visualisation}
-            onClick={this.onChangeShowVisualisation}
+            onClick={this.onToggleShowVisualisation}
           />
         }
         {showVisualisation &&

--- a/frontend/src/components/commits-table/header/Header.tsx
+++ b/frontend/src/components/commits-table/header/Header.tsx
@@ -7,10 +7,11 @@ interface HeaderProps {
   areAllCommitsSelected: boolean;
   selectableCommitsCount: number;
   enableActions: boolean;
+  canToggleVisualisation: boolean;
   showVisualisation: boolean;
   branches: number;
   onSelectAllChange(isChecked: boolean): void;
-  onChangeShowVisualisation(): void;
+  onToggleShowVisualisation(): void;
 }
 
 const Header: React.StatelessComponent<HeaderProps> = (props) => {
@@ -18,10 +19,11 @@ const Header: React.StatelessComponent<HeaderProps> = (props) => {
     areAllCommitsSelected,
     selectableCommitsCount,
     enableActions,
+    canToggleVisualisation,
     showVisualisation,
     onSelectAllChange,
     branches,
-    onChangeShowVisualisation,
+    onToggleShowVisualisation,
   } = props;
 
   return (
@@ -29,12 +31,14 @@ const Header: React.StatelessComponent<HeaderProps> = (props) => {
       <tr>
         <th
           className='column-environment'
-          onClick={onChangeShowVisualisation}
+          onClick={onToggleShowVisualisation}
           style={{ width: showVisualisation ? branches * 20 : 20, cursor: 'pointer' }}
         >
-          <span style={{ paddingLeft: 5, fontSize: '100%', fontWeight: 'bold' }}>
-            {showVisualisation ? '<' : '>'}
-          </span>
+          {canToggleVisualisation &&
+            <span style={{ paddingLeft: 5, fontSize: '100%', fontWeight: 'bold' }}>
+              {showVisualisation ? '<' : '>'}
+            </span>
+          }
         </th>
         <SelectAll
           isSelected={areAllCommitsSelected}

--- a/frontend/src/components/commits-table/row/Row.tsx
+++ b/frontend/src/components/commits-table/row/Row.tsx
@@ -18,7 +18,7 @@ interface RowProps {
   onUndo(hash: string, message: string): void;
   onRollback(hash: string, date: string): void;
   onCommitsSelect(commits: Commit[], isChecked: boolean, isShiftKey: boolean): void;
-  onChangeShowVisualisation(): void;
+  onToggleShowVisualisation(): void;
 }
 
 @observer
@@ -37,7 +37,7 @@ export default class Row extends React.Component<RowProps, {}> {
       onRollback,
       onCommitsSelect,
       showVisualisation,
-      onChangeShowVisualisation,
+      onToggleShowVisualisation,
     } = this.props;
     const { commit, isSelected, detailsLevel, diff, error, isLoading, visualisation } = commitRow;
 
@@ -54,7 +54,7 @@ export default class Row extends React.Component<RowProps, {}> {
           onRollback={onRollback}
           onCommitsSelect={onCommitsSelect}
           onDetailsLevelChange={this.onDetailsLevelChange}
-          onChangeShowVisualisation={onChangeShowVisualisation}
+          onToggleShowVisualisation={onToggleShowVisualisation}
         />
         {error
           ? <Error message={error} />

--- a/frontend/src/components/search/background/Background.less
+++ b/frontend/src/components/search/background/Background.less
@@ -8,12 +8,18 @@
   right: 0;
   top: 0;
   z-index: 1;
+  line-height: 1.4;
   outline: rgb(85, 84, 89) none 0;
   letter-spacing: 0;
   word-spacing: 0;
   margin: 3px 8px 0 8px;
   white-space: pre;
   overflow: hidden;
+
+  &-hint,
+  &-modifier {
+    vertical-align: middle;
+  }
 
   &-hint {
     color: #ccc;

--- a/frontend/src/components/search/modifiers/list/Component.tsx
+++ b/frontend/src/components/search/modifiers/list/Component.tsx
@@ -139,7 +139,6 @@ export default class ListComponent extends ModifierComponent<ListComponentState>
   }
 
   render() {
-    const { token } = this.props;
     const { currentIndex } = this.state;
 
     const groupedList = this.getGroupedList();
@@ -158,7 +157,6 @@ export default class ListComponent extends ModifierComponent<ListComponentState>
               key={item.section}
               currentIndex={currentIndex}
               item={item}
-              token={token}
               onSelectItem={this.onSelectItem}
             />
           ))}

--- a/frontend/src/components/search/modifiers/list/Item.tsx
+++ b/frontend/src/components/search/modifiers/list/Item.tsx
@@ -9,18 +9,16 @@ import ItemList from './ItemList';
 interface ItemProps {
   currentIndex: number;
   item: GroupedItem;
-  token: Token;
   onSelectItem(index: number): void;
 }
 
 const Item: React.StatelessComponent<ItemProps> = (props) => {
-  const { currentIndex, item, token, onSelectItem } = props;
+  const { currentIndex, item, onSelectItem } = props;
 
   return (
     <div>
       <ItemHeader
         item={item}
-        token={token}
       />
 
       {item.list &&

--- a/frontend/src/components/search/modifiers/list/ItemHeader.tsx
+++ b/frontend/src/components/search/modifiers/list/ItemHeader.tsx
@@ -5,10 +5,9 @@ import * as React from 'react';
 
 interface ItemHeaderProps {
   item: GroupedItem;
-  token: Token;
 }
 
-const ItemHeader: React.StatelessComponent<ItemHeaderProps> = ({ item, token }) => {
+const ItemHeader: React.StatelessComponent<ItemHeaderProps> = ({ item }) => {
   const sectionTitle = item.section;
 
   if (!sectionTitle) {

--- a/frontend/src/stores/commitsTableStore.ts
+++ b/frontend/src/stores/commitsTableStore.ts
@@ -9,6 +9,8 @@ import { indexOf } from '../utils/CommitUtils';
 import { generateGraphData } from '../actions/utils';
 import CommitRow from '../entities/CommitRow';
 
+import navigationStore from './navigationStore';
+
 class CommitsTableStore {
 
   @observable commitRows: CommitRow[] = [];
@@ -43,8 +45,13 @@ class CommitsTableStore {
     return branches.length;
   }
 
-  @action changeShowVisualisation = () => {
-    this.showVisualisation = !this.showVisualisation;
+  @action toggleShowVisualisation = (showVisualisation?: boolean) => {
+    if (typeof showVisualisation !== 'boolean' && navigationStore.activeQuery !== '') {
+      return;
+    }
+    this.showVisualisation = typeof showVisualisation === 'boolean'
+      ? showVisualisation
+      : !this.showVisualisation;
 
     if (localStorage) {
       localStorage.setItem('showVisualization', this.showVisualisation ? 'true' : '');

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -6,6 +6,7 @@ import appStore from './appStore';
 
 class NavigationStore {
 
+  @observable activeQuery: string = '';
   @observable query: string = '';
 
   @computed get changesCount() {
@@ -19,6 +20,10 @@ class NavigationStore {
   @action changeFilterQuery = (query: string) => {
     this.query = query;
   };
+
+  @action changeActiveQuery = (activeQuery: string) => {
+    this.activeQuery = activeQuery;
+  }
 
 }
 


### PR DESCRIPTION
Fixes some issues with integrating autocomplete (#805) and commit history visualisation (#1043) together:
- Visualisation is disabled when some search query is active
- Little visual tweaks

Reviewers:

- [x] @Ishirak 