### PR TITLE
Custom `escapeshellarg()` implementation

### DIFF
--- a/plugins/versionpress/src/Cli/VPCommandUtils.php
+++ b/plugins/versionpress/src/Cli/VPCommandUtils.php
@@ -4,6 +4,7 @@ namespace VersionPress\Cli;
 
 use cli\Colors;
 use VersionPress\Utils\Process;
+use VersionPress\Utils\ProcessUtils;
 use WP_CLI;
 
 class VPCommandUtils
@@ -24,9 +25,9 @@ class VPCommandUtils
 
         foreach ($args as $name => $value) {
             if (is_int($name)) { // positional argument
-                $cliCommand .= " " . escapeshellarg($value);
+                $cliCommand .= " " . ProcessUtils::escapeshellarg($value);
             } elseif ($value !== null) {
-                $cliCommand .= " --$name=" . escapeshellarg($value);
+                $cliCommand .= " --$name=" . ProcessUtils::escapeshellarg($value);
             } else {
                 $cliCommand .= " --$name";
             }

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -24,6 +24,7 @@ use VersionPress\Synchronizers\SynchronizationProcess;
 use VersionPress\Utils\FileSystem;
 use VersionPress\Utils\PathUtils;
 use VersionPress\Utils\Process;
+use VersionPress\Utils\ProcessUtils;
 use VersionPress\Utils\RequirementsChecker;
 use VersionPress\Utils\WorkflowUtils;
 use VersionPress\VersionPress;
@@ -481,7 +482,7 @@ class VPCommand extends WP_CLI_Command
         vp_commit_all_frequently_written_entities();
 
         // Clone the site
-        $cloneCommand = sprintf("git clone %s %s", escapeshellarg($currentWpPath), escapeshellarg($clonePath));
+        $cloneCommand = sprintf("git clone %s %s", ProcessUtils::escapeshellarg($currentWpPath), ProcessUtils::escapeshellarg($clonePath));
 
         $process = VPCommandUtils::exec($cloneCommand, $currentWpPath);
 
@@ -494,7 +495,7 @@ class VPCommand extends WP_CLI_Command
 
         // Adding the clone as a remote for the convenience of the `vp pull` command - its `--from`
         // parameter can then be just the name of the clone, not a path to it
-        $addRemoteCommand = sprintf("git remote add %s %s", escapeshellarg($name), escapeshellarg($clonePath));
+        $addRemoteCommand = sprintf("git remote add %s %s", ProcessUtils::escapeshellarg($name), ProcessUtils::escapeshellarg($clonePath));
         $process = VPCommandUtils::exec($addRemoteCommand, $currentWpPath);
 
         if (!$process->isSuccessful()) {
@@ -659,7 +660,7 @@ class VPCommand extends WP_CLI_Command
 
         $remote = isset($assoc_args['from']) ? $assoc_args['from'] : 'origin';
 
-        $process = VPCommandUtils::exec("git config --get remote." . escapeshellarg($remote) . ".url");
+        $process = VPCommandUtils::exec("git config --get remote." . ProcessUtils::escapeshellarg($remote) . ".url");
         $remoteUrl = $process->getConsoleOutput();
 
         if (is_dir($remoteUrl)) {
@@ -671,7 +672,7 @@ class VPCommand extends WP_CLI_Command
         $this->switchMaintenance('on');
 
         $branchToPullFrom = 'master'; // hardcoded until we support custom branches
-        $pullCommand = 'git pull ' . escapeshellarg($remote) . ' ' . $branchToPullFrom;
+        $pullCommand = 'git pull ' . ProcessUtils::escapeshellarg($remote) . ' ' . $branchToPullFrom;
         $process = VPCommandUtils::exec($pullCommand);
 
         if ($process->isSuccessful()) {

--- a/plugins/versionpress/src/Git/GitRepository.php
+++ b/plugins/versionpress/src/Git/GitRepository.php
@@ -5,6 +5,7 @@ namespace VersionPress\Git;
 use Nette\Utils\Strings;
 use VersionPress\Utils\FileSystem;
 use VersionPress\Utils\Process;
+use VersionPress\Utils\ProcessUtils;
 
 /**
  * Manipulates the Git repository.
@@ -177,7 +178,7 @@ class GitRepository
 
         $logCommand .= " " . $options;
         if (!empty($gitrevisions)) {
-            $logCommand .= " " . escapeshellarg($gitrevisions);
+            $logCommand .= " " . ProcessUtils::escapeshellarg($gitrevisions);
         }
 
         $logCommand = str_replace("|begin|", $commitDelimiter, $logCommand);
@@ -399,7 +400,7 @@ class GitRepository
 
             if (count($filesToReset) > 0) {
                 $this->runShellCommand(
-                    sprintf("git reset HEAD %s", join(" ", array_map('escapeshellarg', $filesToReset)))
+                    sprintf("git reset HEAD %s", join(" ", array_map(['VersionPress\Utils\ProcessUtils', 'escapeshellarg'], $filesToReset)))
                 );
             }
 
@@ -411,7 +412,7 @@ class GitRepository
             $emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
             $gitCmd = "git diff-tree -p $emptyTreeHash $hash";
         } else {
-            $escapedHash = escapeshellarg($hash);
+            $escapedHash = ProcessUtils::escapeshellarg($hash);
             $gitCmd = "git diff $escapedHash~1 $escapedHash";
         }
 
@@ -492,9 +493,9 @@ class GitRepository
 
         // replace (optional) "git " with the configured git binary
         $command = Strings::startsWith($command, "git ") ? substr($command, 4) : $command;
-        $command = escapeshellarg($this->gitBinary) . " " . $command;
+        $command = ProcessUtils::escapeshellarg($this->gitBinary) . " " . $command;
 
-        $escapedArgs = @array_map("escapeshellarg", $args);
+        $escapedArgs = @array_map(['VersionPress\Utils\ProcessUtils', 'escapeshellarg'], $args);
         $commandWithArguments = vsprintf($command, $escapedArgs);
 
         $result = $this->runProcess($commandWithArguments);

--- a/plugins/versionpress/src/Utils/ProcessUtils.php
+++ b/plugins/versionpress/src/Utils/ProcessUtils.php
@@ -6,18 +6,19 @@ class ProcessUtils
 {
 
     /**
-     * Similar to built-in escapeshellarg() but allows to pass OS according to which
-     * the escaping should be done (Linux - quotes, Windows - double quotes).
+     * `escapeshellarg()` reimplementation that is custom-coded for both Linux and Windows. This fixes some
+     * bugs on Windows (quotes not escaped properly) and allows you to force the escaping type
+     * using the `$os` parameter should you need to.
      *
-     * @param $arg
-     * @param string|null $os "windows", "linux" or null to use the OS detection in escapeshellarg()
+     * @param string $arg
+     * @param string|null $os "windows", "linux" or null to auto-detect
      * @return mixed|string
      */
     public static function escapeshellarg($arg, $os = null)
     {
 
         if (!$os) {
-            return escapeshellarg($arg);
+            $os = DIRECTORY_SEPARATOR == '\\' ? "windows" : "linux";
         }
 
         if ($os == "windows") {

--- a/plugins/versionpress/src/Utils/RequirementsChecker.php
+++ b/plugins/versionpress/src/Utils/RequirementsChecker.php
@@ -258,7 +258,7 @@ class RequirementsChecker
             FileSystem::remove($filePath);
 
             // Trying to create file from process (issue #522)
-            $process = new Process(sprintf("echo test > %s", escapeshellarg($filePath)));
+            $process = new Process(sprintf("echo test > %s", ProcessUtils::escapeshellarg($filePath)));
             $process->run();
             $writable &= is_file($filePath);
 

--- a/plugins/versionpress/src/Utils/SystemInfo.php
+++ b/plugins/versionpress/src/Utils/SystemInfo.php
@@ -42,7 +42,7 @@ class SystemInfo
 
         $info = [];
 
-        $process = new Process(escapeshellarg($gitBinary) . " --version");
+        $process = new Process(ProcessUtils::escapeshellarg($gitBinary) . " --version");
         $process->run();
 
         $info['git-binary-as-configured'] = $gitBinary;
@@ -268,7 +268,7 @@ class SystemInfo
             $processInfo['php-can-delete'][$target] = !is_file($filePath);
 
             $filePath = $directory . '/' . '.vp-try-write-process';
-            $process = new Process(sprintf("echo test > %s", escapeshellarg($filePath)));
+            $process = new Process(sprintf("echo test > %s", ProcessUtils::escapeshellarg($filePath)));
             $process->run();
             $processInfo['process-can-write'][$target] = is_file($filePath);
             try {

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -757,7 +757,7 @@ class WpAutomation
 
         $command = substr($command, 3); // strip "wp " prefix
 
-        $command = "php " . escapeshellarg($this->getWpCli()) . " $command";
+        $command = "php " . ProcessUtils::escapeshellarg($this->getWpCli()) . " $command";
 
         return $command;
 

--- a/plugins/versionpress/tests/End2End/Plugins/PluginsTest.php
+++ b/plugins/versionpress/tests/End2End/Plugins/PluginsTest.php
@@ -6,6 +6,7 @@ use VersionPress\Tests\End2End\Utils\End2EndTestCase;
 use VersionPress\Tests\Utils\CommitAsserter;
 use VersionPress\Tests\Utils\DBAsserter;
 use VersionPress\Utils\Process;
+use VersionPress\Utils\ProcessUtils;
 
 class PluginsTest extends End2EndTestCase
 {
@@ -65,7 +66,7 @@ class PluginsTest extends End2EndTestCase
         }
 
         $process = new Process(
-            "git add -A && git commit -m " . escapeshellarg("Plugin setup"),
+            "git add -A && git commit -m " . ProcessUtils::escapeshellarg("Plugin setup"),
             self::$testConfig->testSite->path
         );
         $process->run();

--- a/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
+++ b/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
@@ -18,6 +18,7 @@ use VersionPress\Tests\Utils\DBAsserter;
 use VersionPress\Tests\Utils\TestConfig;
 use VersionPress\Utils\AbsoluteUrlReplacer;
 use VersionPress\Utils\Process;
+use VersionPress\Utils\ProcessUtils;
 use wpdb;
 
 class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
@@ -101,7 +102,7 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
     public static function tearDownAfterClass()
     {
         $process = new Process(
-            "git add -A && git commit -m " . escapeshellarg("Commited changes made by " . get_called_class()),
+            "git add -A && git commit -m " . ProcessUtils::escapeshellarg("Commited changes made by " . get_called_class()),
             self::$testConfig->testSite->path
         );
         $process->run();


### PR DESCRIPTION
Resolves #1132

Two main changes:

1. `ProcessUtils::escapeshellarg()` now always uses custom implementation and doesn't fall back to PHP's `escapeshellarg()`.
2. Changed all ocurrences of `escapeshellarg()` to `ProcessUtils::escapeshellarg()`. This was not strictly necessary but at least the escaping is now used consistently throughout the project.

Reviewers:

- [x] @JanVoracek 
