### PR TITLE
Fix jQuery require for WebUI popover

### DIFF
--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -882,7 +882,7 @@ function vp_enqueue_styles_and_scripts()
         wp_enqueue_script(
             'versionpress_popover_script',
             plugins_url('admin/public/js/jquery.webui-popover.min.js', VERSIONPRESS_PLUGIN_FILE),
-            'jquery',
+            ['jquery'],
             $vpVersion
         );
     }


### PR DESCRIPTION
Resolves # .

This resolves a JS console error I was encountering on a theme that deregisters jQuery and re-registers it to run in the footer to defer jQuery loading.

Reviewers:

- [ ] @versionpress/core-devs
Resolves issues with themes that use their own jQuery instead of WordPress' built-in version.