### PR TITLE
Resolve JS console error if jQuery is in footer

### DIFF
--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -882,7 +882,7 @@ function vp_enqueue_styles_and_scripts()
         wp_enqueue_script(
             'versionpress_popover_script',
             plugins_url('admin/public/js/jquery.webui-popover.min.js', VERSIONPRESS_PLUGIN_FILE),
-            'jquery',
+            array('jquery'),
             $vpVersion
         );
     }


### PR DESCRIPTION
This resolves a JS console error I was encountering on a theme that deregisters jQuery and re-registers it to run in the footer to defer jQuery loading. The dependency argument of wp_enqueue_script should be an array.

Reviewers:

- [x] @JanVoracek
