### PR TITLE
1158 - relative paths on Windows fix

### DIFF
--- a/plugins/versionpress/src/Utils/PathUtils.php
+++ b/plugins/versionpress/src/Utils/PathUtils.php
@@ -14,8 +14,9 @@ class PathUtils
     public static function getRelativePath($from, $to)
     {
         // Windows FTW!
-        $from = str_replace('\\', '/', $from);
-        $to = str_replace('\\', '/', $to);
+        $from = self::windowsFix($from);
+        $to = self::windowsFix($to);
+
 
         $from = preg_replace('~([^/]*)/+([^/]*)~', '$1/$2', $from);
         $to = preg_replace('~([^/]*)/+([^/]*)~', '$1/$2', $to);
@@ -40,6 +41,22 @@ class PathUtils
         $relPath = array_pad($relPath, $totalLengthOfRelativePath * -1, '..');
 
         return implode('/', $relPath);
+    }
+
+    /**
+     * Converts '\' to '/' and makes disk drive (e.g., C:) case insensitive
+     *
+     * @param string $path
+     * @return string
+     */
+    private static function windowsFix($path)
+    {
+        $path = str_replace('\\', '/', $path);
+        // https://regex101.com/r/RRtZKq/2
+        if (preg_match('/^(\w)(\:.*)/', $path, $matches)) {
+            $path = strtolower($matches[1]) . $matches[2];
+        }
+        return $path;
     }
 
     private static function countCommonDepth($from, $to)

--- a/plugins/versionpress/tests/Unit/RelativePathsTest.php
+++ b/plugins/versionpress/tests/Unit/RelativePathsTest.php
@@ -48,9 +48,10 @@ class RelativePathsTest extends \PHPUnit_Framework_TestCase
             '/some/dir/', // non-existing directory with trailing slash
             str_replace('/', '\\', __DIR__), // existing directory with backslashes
             str_replace('/', '\\', __DIR__) . '/', // existing directory with backslashes and trailing slash
-            'c:\\some\\dir', // Windows-like path
-            'c:\\some\\dir\\', // Windows-like path with trailing backslash
-            'c:\\some\\dir/', // Windows-like path with trailing slash
+            'C:\\some\\dir', // Windows-like path
+            'C:\\some\\dir\\', // Windows-like path with trailing backslash
+            'C:\\some\\dir/', // Windows-like path with trailing slash
+            'c:\\some\\dir', // lower-case c:
         ];
 
         // Used instead of dirname() because of testing Windows paths on Unix-like OS
@@ -74,6 +75,9 @@ class RelativePathsTest extends \PHPUnit_Framework_TestCase
             ];
         }, $testedRoots);
 
-        return call_user_func_array('array_merge', $testCasesForRoots);
+        $testCases = call_user_func_array('array_merge', $testCasesForRoots);
+        $testCases[] = ['c:\\path', 'C:\\path', '']; // c: vs. C: shouldn't matter (other than that, path calculation is case sensitive even on Windows)
+
+        return $testCases;
     }
 }

--- a/plugins/versionpress/tests/test-config.sample.yml
+++ b/plugins/versionpress/tests/test-config.sample.yml
@@ -43,7 +43,7 @@ sites:
       user: vp01
       password: vp01
     wp-site:
-      # on Windows, the path is like c:/wamp/www/vp01
+      # on Windows, the path is like C:/wamp/www/vp01
       path: /Users/johdoe/Sites/vp01
       url: http://localhost/vp01
       wp-admin-path: wp-admin


### PR DESCRIPTION
Resolves #1158.

Makes `PathUtils::getRelativePath()` more permissive, updates Windows path example in test-config.sample.yml.