### PR TITLE
sticky_posts option added to value-references in schema.yml

### DIFF
--- a/plugins/versionpress/.versionpress/schema.yml
+++ b/plugins/versionpress/.versionpress/schema.yml
@@ -122,6 +122,7 @@ option:
       widget_pages[/\d+/]["exclude"]: post
       nav_menu_options["auto_add"][/\d+/]: term
       featured-content["tag-id"]: term
+      sticky_posts[/\d+/]: post
       theme_mods_*["nav_menu_locations"][/.*/]: term
       theme_mods_*["header_image_data"]["attachment_id"]: post
       theme_mods_*["custom_logo"]: post


### PR DESCRIPTION
Resolves #1171

`sticky_posts` option added to `value-references` in `schema.yml`.

