### PR TITLE
Added VP_WP_CLI_BINARY option to vp config

### DIFF
--- a/plugins/versionpress/bootstrap.php
+++ b/plugins/versionpress/bootstrap.php
@@ -38,6 +38,20 @@ if (!defined('VP_GIT_BINARY')) {
     define('VP_GIT_BINARY', 'git');
 }
 
+if (!defined('VP_GIT_BINARY')) {
+    /**
+     * Absolute path to the git executable. Useful if it's not in PATH.
+     */
+    define('VP_GIT_BINARY', 'git');
+}
+
+if (!defined('VP_WP_CLI_BINARY')) {
+    /**
+     * Absolute path to the WP-CLI executable. Useful if it's not in PATH.
+     */
+    define('VP_WP_CLI_BINARY', 'wp');
+}
+
 if (!defined('VERSIONPRESS_GUI')) {
     /**
      * Which GUI to use. Used mainly for testing.

--- a/plugins/versionpress/bootstrap.php
+++ b/plugins/versionpress/bootstrap.php
@@ -38,13 +38,6 @@ if (!defined('VP_GIT_BINARY')) {
     define('VP_GIT_BINARY', 'git');
 }
 
-if (!defined('VP_GIT_BINARY')) {
-    /**
-     * Absolute path to the git executable. Useful if it's not in PATH.
-     */
-    define('VP_GIT_BINARY', 'git');
-}
-
 if (!defined('VP_WP_CLI_BINARY')) {
     /**
      * Absolute path to the WP-CLI executable. Useful if it's not in PATH.

--- a/plugins/versionpress/src/Cli/VPCommandUtils.php
+++ b/plugins/versionpress/src/Cli/VPCommandUtils.php
@@ -12,7 +12,7 @@ class VPCommandUtils
     public static function runWpCliCommand($command, $subcommand, $args = [], $cwd = null)
     {
 
-        $cliCommand = "wp $command";
+        $cliCommand = VP_WP_CLI_BINARY . " $command";
 
         if ($subcommand) {
             $cliCommand .= " $subcommand";

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -44,11 +44,12 @@ class VPCommand extends WP_CLI_Command
      *
      * <constant>
      * : The name of the constant to set.
-     *   VP_GIT_BINARY:   Absolute path to the git binary.
-     *   VP_PROJECT_ROOT: Absolute path to the root of your project (typically
-     *                    where is the .git directory)
-     *   VP_VPDB_DIR:     Absolute path to directory where VersionPress saves
-     *                    versioned database data.
+     *   VP_GIT_BINARY:     Absolute path to the git binary.
+     *   VP_WP_CLI_BINARY:  Absolute path to the WP-CLI binary.
+     *   VP_PROJECT_ROOT:   Absolute path to the root of your project (typically
+     *                      where is the .git directory)
+     *   VP_VPDB_DIR:       Absolute path to directory where VersionPress saves
+     *                      versioned database data.
      *
      * [<value>]
      * : The new value. If missing, just prints out current value.
@@ -64,6 +65,10 @@ class VPCommand extends WP_CLI_Command
          */
         $allowedConstants = [
             'VP_GIT_BINARY' => [
+                'common' => false,
+                'type' => 'absolute-path',
+            ],
+            'VP_WP_CLI_BINARY' => [
                 'common' => false,
                 'type' => 'absolute-path',
             ],

--- a/plugins/versionpress/src/Initialization/Initializer.php
+++ b/plugins/versionpress/src/Initialization/Initializer.php
@@ -635,8 +635,8 @@ class Initializer
         if ((!isset($composerJson->scripts->{'pre-update-cmd'}) || $composerJson->scripts->{'pre-update-cmd'} === '') &&
             (!isset($composerJson->scripts->{'post-update-cmd'}) || $composerJson->scripts->{'post-update-cmd'} === '')
         ) {
-            $composerJson->scripts->{'pre-update-cmd'} = 'wp vp-composer prepare-for-composer-changes';
-            $composerJson->scripts->{'post-update-cmd'} = 'wp vp-composer commit-composer-changes';
+            $composerJson->scripts->{'pre-update-cmd'} = VP_WP_CLI_BINARY . ' vp-composer prepare-for-composer-changes';
+            $composerJson->scripts->{'post-update-cmd'} = VP_WP_CLI_BINARY . ' vp-composer commit-composer-changes';
 
             file_put_contents($composerJsonPath, json_encode($composerJson, JSON_PRETTY_PRINT));
         }

--- a/plugins/versionpress/src/Utils/SystemInfo.php
+++ b/plugins/versionpress/src/Utils/SystemInfo.php
@@ -28,6 +28,8 @@ class SystemInfo
         $output['summary']['git-full-path'] =
             isset($output['git-info']['git-full-path']) ? $output['git-info']['git-full-path'] : '';
 
+        $output['summary']['wp-cli-full-path'] = VP_WP_CLI_BINARY;
+
         return $output;
     }
 

--- a/plugins/versionpress/src/Utils/WpConfigEditor.php
+++ b/plugins/versionpress/src/Utils/WpConfigEditor.php
@@ -18,6 +18,7 @@ class WpConfigEditor
         'VP_PROJECT_ROOT',
         'VP_ENVIRONMENT',
         'VP_GIT_BINARY',
+        'VP_WP_CLI_BINARY',
     ];
 
     public function __construct($wpConfigPath, $isCommonConfig)

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -125,7 +125,7 @@ class WpAutomation
      */
     public function activateVersionPress()
     {
-        $activateCommand = "wp plugin activate versionpress";
+        $activateCommand = VP_WP_CLI_BINARY . " plugin activate versionpress";
         $this->exec($activateCommand);
     }
 
@@ -419,7 +419,7 @@ class WpAutomation
     {
         $widgets = trim(is_array($widgets) ? join(' ', $widgets) : $widgets);
         if (strlen($widgets) > 0) {
-            $this->exec('wp widget delete ' . $widgets);
+            $this->exec(VP_WP_CLI_BINARY . ' widget delete ' . $widgets);
         }
     }
 
@@ -542,7 +542,7 @@ class WpAutomation
             $entityParameters .= "--$entity=$count ";
         }
 
-        $command = "wp --require=\"$vpAutomateFile\" vp-automate generate $entityParameters";
+        $command = VP_WP_CLI_BINARY . " --require=\"$vpAutomateFile\" vp-automate generate $entityParameters";
         $this->exec($command, $this->siteConfig->path);
     }
 
@@ -572,7 +572,7 @@ class WpAutomation
 
             $wpVersion = $this->siteConfig->wpVersion;
             $wpLocale = $this->siteConfig->wpLocale;
-            $downloadCommand = "wp core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
+            $downloadCommand = VP_WP_CLI_BINARY . " core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
             if ($wpLocale) {
                 $downloadCommand .= " --locale=$wpLocale";
             }
@@ -718,7 +718,7 @@ class WpAutomation
     public function runWpCliCommand($command, $subcommand, $args = [], $debug = false)
     {
 
-        $cliCommand = "wp $command";
+        $cliCommand = VP_WP_CLI_BINARY . " $command";
 
         if ($subcommand) {
             $cliCommand .= " $subcommand";
@@ -751,11 +751,11 @@ class WpAutomation
     private function rewriteWpCliCommand($command)
     {
 
-        if (!Strings::startsWith($command, "wp ")) {
+        if (!Strings::startsWith($command, VP_WP_CLI_BINARY . " ")) {
             return $command;
         }
 
-        $command = substr($command, 3); // strip "wp " prefix
+        $command = substr($command, strlen(VP_WP_CLI_BINARY . " ")); // strip "wp " prefix
 
         $command = "php " . ProcessUtils::escapeshellarg($this->getWpCli()) . " $command";
 

--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -125,7 +125,7 @@ class WpAutomation
      */
     public function activateVersionPress()
     {
-        $activateCommand = VP_WP_CLI_BINARY . " plugin activate versionpress";
+        $activateCommand = "wp plugin activate versionpress";
         $this->exec($activateCommand);
     }
 
@@ -419,7 +419,7 @@ class WpAutomation
     {
         $widgets = trim(is_array($widgets) ? join(' ', $widgets) : $widgets);
         if (strlen($widgets) > 0) {
-            $this->exec(VP_WP_CLI_BINARY . ' widget delete ' . $widgets);
+            $this->exec('wp widget delete ' . $widgets);
         }
     }
 
@@ -542,7 +542,7 @@ class WpAutomation
             $entityParameters .= "--$entity=$count ";
         }
 
-        $command = VP_WP_CLI_BINARY . " --require=\"$vpAutomateFile\" vp-automate generate $entityParameters";
+        $command = "wp --require=\"$vpAutomateFile\" vp-automate generate $entityParameters";
         $this->exec($command, $this->siteConfig->path);
     }
 
@@ -572,7 +572,7 @@ class WpAutomation
 
             $wpVersion = $this->siteConfig->wpVersion;
             $wpLocale = $this->siteConfig->wpLocale;
-            $downloadCommand = VP_WP_CLI_BINARY . " core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
+            $downloadCommand = "wp core download --path=\"$cleanInstallationPath\" --version=\"$wpVersion\"";
             if ($wpLocale) {
                 $downloadCommand .= " --locale=$wpLocale";
             }
@@ -718,7 +718,7 @@ class WpAutomation
     public function runWpCliCommand($command, $subcommand, $args = [], $debug = false)
     {
 
-        $cliCommand = VP_WP_CLI_BINARY . " $command";
+        $cliCommand = "wp $command";
 
         if ($subcommand) {
             $cliCommand .= " $subcommand";
@@ -751,11 +751,11 @@ class WpAutomation
     private function rewriteWpCliCommand($command)
     {
 
-        if (!Strings::startsWith($command, VP_WP_CLI_BINARY . " ")) {
+        if (!Strings::startsWith($command, "wp ")) {
             return $command;
         }
 
-        $command = substr($command, strlen(VP_WP_CLI_BINARY . " ")); // strip "wp " prefix
+        $command = substr($command, 3); // strip "wp " prefix
 
         $command = "php " . ProcessUtils::escapeshellarg($this->getWpCli()) . " $command";
 


### PR DESCRIPTION
Resolves #1186 

Creates new [config constant](https://docs.versionpress.net/en/getting-started/configuration#versionpress-config-constants) which gives an option to set custom path to [WP-CLI](http://wp-cli.org/). 
Works same way as _VP_GIT_BINARY_:

`wp vp config VP_WP_CLI_BINARY '/custom/path/to/wp'`
