### PR TITLE
AutocompleteUtils::capitalize() made static

### DIFF
--- a/plugins/versionpress/src/Utils/AutocompleteUtils.php
+++ b/plugins/versionpress/src/Utils/AutocompleteUtils.php
@@ -110,7 +110,7 @@ class AutocompleteUtils
      * @param $string
      * @return string
      */
-    private function capitalize($string)
+    private static function capitalize($string)
     {
         $capitalizedString = Strings::firstUpper($string);
         return str_ireplace(


### PR DESCRIPTION
Resolves #1196 

Tiny syntax fix.
