### PR TITLE
Better format for parent's private fields in INI serializer

### DIFF
--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -147,6 +147,7 @@ class SerializedDataToIniConverter
 
                     $attributeName = str_replace("\0*\0", '*', $attributeName);
                     $attributeName = str_replace("\0{$className}\0", '-', $attributeName);
+                    $attributeName = preg_replace("/^\\0(.*)\\0(.*)$/", "-\$1->\$2", $attributeName);
 
                     $attributeValue = self::parseSerializedString();
 
@@ -337,8 +338,15 @@ class SerializedDataToIniConverter
                 return "\"\0*\0" . substr($subkey, 2);
             }
 
-            if (strpos($subkey, '-') === 1) {
+            $objectOperatorPosition = strpos($subkey, '->');
+            if (strpos($subkey, '-') === 1 && $objectOperatorPosition === false) {
                 return "\"\0{$type}\0" . substr($subkey, 2);
+            }
+
+            if (strpos($subkey, '-') === 1) {
+                $parentClass = str_replace('\\\\', '\\', substr($subkey, 2, $objectOperatorPosition - 2));
+                $attributeName = substr($subkey, $objectOperatorPosition + 2, strlen($subkey) - 2);
+                return "\"\0{$parentClass}\0{$attributeName}";
             }
 
             return $subkey;

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -1144,6 +1144,28 @@ INI
     /**
      * @test
      */
+    public function serializedCustomClassWithPrivateAttributeInParent()
+    {
+        $object = new IniSerializer_FooPrivateChild('value');
+
+        $serializedString = serialize($object);
+
+        $data = ["Section" => ["data" => $serializedString]];
+        $ini = StringUtils::ensureLf(<<<'INI'
+[Section]
+data = <<<serialized>>> <VersionPress\Tests\Unit\IniSerializer_FooPrivateChild>
+data["-VersionPress\\Tests\\Unit\\IniSerializer_FooPrivate->attribute"] = "value"
+
+INI
+        );
+
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+    }
+
+    /**
+     * @test
+     */
     public function serializedNull()
     {
         $serializedString = serialize(null);

--- a/plugins/versionpress/tests/Unit/IniSerializer_FooClasses.php
+++ b/plugins/versionpress/tests/Unit/IniSerializer_FooClasses.php
@@ -60,3 +60,8 @@ class IniSerializer_FooWithCleanup
         return 'cached attribute: ' . $attribute;
     }
 }
+
+class IniSerializer_FooPrivateChild extends IniSerializer_FooPrivate
+{
+
+}


### PR DESCRIPTION
Resolves #1224.

The field is now saved as e.g. `option_value["-Some\\Parent\\Class->attribute"] = "value"`.