### PR TITLE
Deleting plugin or theme does not create a commit

### DIFF
--- a/plugins/versionpress/tests/End2End/Plugins/PluginsTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Plugins/PluginsTestSeleniumWorker.php
@@ -40,7 +40,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function activatePlugin()
     {
-        $this->byCssSelector(".activate a[href*='" .  self::$pluginInfo['url-fragment'] . "']")->click();
+        $this->byCssSelector(".activate a[href*='" . self::$pluginInfo['url-fragment'] . "']")->click();
         $this->waitAfterRedirect();
     }
 
@@ -51,7 +51,7 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
 
     public function deactivatePlugin()
     {
-        $this->byCssSelector(".deactivate a[href*='" .  self::$pluginInfo['url-fragment'] . "']")->click();
+        $this->byCssSelector(".deactivate a[href*='" . self::$pluginInfo['url-fragment'] . "']")->click();
         $this->waitAfterRedirect();
     }
 
@@ -59,12 +59,18 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
     {
     }
 
-    public function deletePlugin() 
+    public function deletePlugin()
     {
-        $this->byCssSelector(".delete a[href*='" .  self::$pluginInfo['url-fragment'] . "']")->click();
-        $this->waitAfterRedirect();
-        $this->byCssSelector("#submit")->click();
-        $this->waitAfterRedirect();
+        $this->byCssSelector(".delete a[href*='" . self::$pluginInfo['url-fragment'] . "']")->click();
+
+        if ($this->isWpVersionLowerThan('4.6')) {
+            $this->waitAfterRedirect();
+            $this->byCssSelector("#submit")->click();
+            $this->waitAfterRedirect();
+        } else {
+            $this->acceptAlert();
+            $this->waitForAjax();
+        }
     }
 
     public function prepare_installTwoPlugins()
@@ -110,16 +116,21 @@ class PluginsTestSeleniumWorker extends SeleniumWorker implements IPluginsTestWo
     public function uninstallTwoPlugins()
     {
         $this->performBulkAction('delete-selected');
-        $this->byId('submit')->click();
+        if ($this->isWpVersionLowerThan('4.7')) {
+            $this->byId('submit')->click();
+        } else {
+            $this->acceptAlert();
+            $this->waitForAjax();
+        }
     }
 
     private function performBulkAction($action)
     {
         // select two plugins
-        $this->byCssSelector('.check-column input[value*="' .  self::$pluginInfo['url-fragment'] . '"]')->click();
-        $this->byCssSelector('.check-column input[value*="' .  self::$secondPluginInfo['url-fragment'] . '"]')->click();
+        $this->byCssSelector('.check-column input[value*="' . self::$pluginInfo['url-fragment'] . '"]')->click();
+        $this->byCssSelector('.check-column input[value*="' . self::$secondPluginInfo['url-fragment'] . '"]')->click();
         // choose bulk edit
         $this->select($this->byId('bulk-action-selector-top'))->selectOptionByValue($action);
-        $this->jsClickAndWait('#doaction');
+        $this->byId('doaction')->click();
     }
 }

--- a/plugins/versionpress/tests/End2End/Themes/ThemesTestSeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Themes/ThemesTestSeleniumWorker.php
@@ -26,6 +26,10 @@ class ThemesTestSeleniumWorker extends SeleniumWorker implements IThemesTestWork
 
     public function uploadTheme()
     {
+        if (version_compare(self::$testConfig->testSite->wpVersion, '4.6', '>=')) {
+            $this->byCssSelector('button.upload-view-toggle')->click();
+        }
+
         $this->byCssSelector('input[name=themezip]')->value(self::$themeInfo['zipfile']);
         $this->byCssSelector('#install-theme-submit')->click();
         $this->waitAfterRedirect();


### PR DESCRIPTION
Resolves #1191

WP now sends multiple AJAX requests for bulk deleting plugins. There is no way we can recognize multiple quick manual clicks vs. bulk action. Therefore, VP makes a separate commit for every deleted plugin.