### PR TITLE
Missing value for VP-Term-Taxonomy

### DIFF
--- a/plugins/versionpress/.versionpress/actions.yml
+++ b/plugins/versionpress/.versionpress/actions.yml
@@ -70,6 +70,7 @@ term_taxonomy:
   tags:
     VP-TermTaxonomy-Taxonomy: taxonomy
     VP-Term-Name: /
+    VP-Term-Id: vp_term_id
   actions:
     create: New %VP-TermTaxonomy-Taxonomy% '%VP-Term-Name%'
     edit:

--- a/plugins/versionpress/.versionpress/hooks.php
+++ b/plugins/versionpress/.versionpress/hooks.php
@@ -258,10 +258,19 @@ add_filter('vp_entity_action_term', function ($action, $oldEntity, $newEntity) {
 }, 10, 3);
 
 add_filter('vp_entity_tags_term', function ($tags, $oldEntity, $newEntity, $action) {
+    global $versionPressContainer;
+    /** @var VpidRepository $vpidRepository */
+    $vpidRepository = $versionPressContainer->resolve(VersionPressServices::VPID_REPOSITORY);
 
     if ($action === 'rename') {
         $tags['VP-Term-OldName'] = $oldEntity['name'];
     }
+
+    $termVpid = $newEntity ? $newEntity['vp_id'] : $oldEntity['vp_id'];
+    $termId = $vpidRepository->getIdForVpid($termVpid);
+
+    $term = get_term($termId);
+    $tags['VP-Term-Taxonomy'] = $term instanceof WP_Term ? $term->taxonomy : 'term';
 
     return $tags;
 }, 10, 4);

--- a/plugins/versionpress/src/Actions/ActionsInfo.php
+++ b/plugins/versionpress/src/Actions/ActionsInfo.php
@@ -75,6 +75,7 @@ class ActionsInfo
         }
 
         $message = str_replace('%VPID%', $vpid, $message);
+        $message = ucfirst($message);
 
         return apply_filters("vp_action_description_{$this->scope}", $message, $action, $vpid, $tags);
     }

--- a/plugins/versionpress/src/Git/ChangeInfoPreprocessors/TermTaxonomyPreprocessor.php
+++ b/plugins/versionpress/src/Git/ChangeInfoPreprocessors/TermTaxonomyPreprocessor.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace VersionPress\Git\ChangeInfoPreprocessors;
+
+use VersionPress\ChangeInfos\ChangeInfo;
+use VersionPress\ChangeInfos\ChangeInfoFactory;
+use VersionPress\ChangeInfos\TrackedChangeInfo;
+
+class TermTaxonomyPreprocessor implements ChangeInfoPreprocessor
+{
+
+    /** @var ChangeInfoFactory */
+    private $changeInfoFactory;
+
+    public function __construct(ChangeInfoFactory $changeInfoFactory)
+    {
+        $this->changeInfoFactory = $changeInfoFactory;
+    }
+
+    /**
+     * Reads taxonomy from `term_taxonomy` action and assings it to `term`.
+     *
+     * @param ChangeInfo[] $changeInfoList
+     * @return ChangeInfo[][]
+     */
+    public function process($changeInfoList)
+    {
+        /** @var TrackedChangeInfo[] $termChangeInfos */
+        $termChangeInfos = array_filter($changeInfoList, function ($changeInfo) {
+            return $changeInfo instanceof TrackedChangeInfo && $changeInfo->getScope() === 'term';
+        });
+
+        if (!$termChangeInfos) {
+            return [$changeInfoList];
+        }
+
+        /** @var TrackedChangeInfo[] $termTaxonomyChangeInfos */
+        $termTaxonomyChangeInfos = array_filter($changeInfoList, function ($changeInfo) {
+            return $changeInfo instanceof TrackedChangeInfo && $changeInfo->getScope() === 'term_taxonomy';
+        });
+
+        $taxonomies = array_combine(
+            array_map(function (TrackedChangeInfo $changeInfo) {
+                return $changeInfo->getCustomTags()['VP-Term-Id'];
+            }, $termTaxonomyChangeInfos),
+            array_map(function (TrackedChangeInfo $changeInfo) {
+                return $changeInfo->getCustomTags()['VP-TermTaxonomy-Taxonomy'];
+            }, $termTaxonomyChangeInfos)
+        );
+
+        foreach ($termChangeInfos as $i => $termChangeInfo) {
+            $termId = $termChangeInfo->getId();
+            if (isset($taxonomies[$termId])) {
+                $tags = $termChangeInfo->getCustomTags();
+                $tags['VP-Term-Taxonomy'] = $taxonomies[$termId];
+
+                $changeInfoList[$i] = $this->changeInfoFactory->createTrackedChangeInfo(
+                    $termChangeInfo->getScope(),
+                    $termChangeInfo->getAction(),
+                    $termChangeInfo->getId(),
+                    $tags,
+                    $termChangeInfo->getChangedFiles()
+                );
+            }
+        }
+
+        return [$changeInfoList];
+    }
+}

--- a/plugins/versionpress/src/Git/Committer.php
+++ b/plugins/versionpress/src/Git/Committer.php
@@ -9,6 +9,7 @@ use VersionPress\Git\ChangeInfoPreprocessors\ChangeInfoPreprocessor;
 use VersionPress\Git\ChangeInfoPreprocessors\EditActionChangeInfoPreprocessor;
 use VersionPress\Git\ChangeInfoPreprocessors\PostChangeInfoPreprocessor;
 use VersionPress\Git\ChangeInfoPreprocessors\PostTermSplittingPreprocessor;
+use VersionPress\Git\ChangeInfoPreprocessors\TermTaxonomyPreprocessor;
 use VersionPress\Storages\Mirror;
 use VersionPress\Storages\StorageFactory;
 use VersionPress\Utils\FileSystem;
@@ -142,6 +143,7 @@ class Committer
             EditActionChangeInfoPreprocessor::class,
             PostChangeInfoPreprocessor::class,
             PostTermSplittingPreprocessor::class,
+            TermTaxonomyPreprocessor::class,
         ];
 
         $changeInfoLists = [$changeInfoList];


### PR DESCRIPTION
Resolves #1167 

<img width="585" alt="screen shot 2017-06-11 at 19 27 16" src="https://user-images.githubusercontent.com/703215/27013031-0b0eb428-4edc-11e7-9c61-fa23375344ed.png">

The code in `TermTaxonomyPreprocessor` is only temporary – until #1123.