### PR TITLE
Revised system requirements for 4.0-beta

### DIFF
--- a/docs/content/en/01-getting-started/02-installation-uninstallation.md
+++ b/docs/content/en/01-getting-started/02-installation-uninstallation.md
@@ -24,9 +24,9 @@ The server environment must match certain requirements, some of which are checke
 
 Minimum system requirements are (as a general rule, **we recommend using the latest versions of everything**):
 
- - WordPress 4.4 or higher (4.1+ should work but is not thoroughly tested)
+ - WordPress 4.8 or higher
  - PHP 5.6 or higher
- - Git 1.9 or higher installed on the server
+ - Git 1.9 or higher (2.13 or newer recommended)
  - Apache, nginx or IIS 7+ web server
  - `proc_open()` enabled
  - Write permissions in the site root and everywhere under it


### PR DESCRIPTION
Resolves #1200 

Required WordPress version bumped to 4.8. PHP stays on 5.6, Git on 1.9 but 2.13+ is now recommended.

No actual change in RequirementsChecker was necessary, just updated docs.
