### PR TITLE
--allow-root for nested WP-CLI commands

### DIFF
--- a/plugins/versionpress/src/Cli/VPCommandUtils.php
+++ b/plugins/versionpress/src/Cli/VPCommandUtils.php
@@ -23,6 +23,8 @@ class VPCommandUtils
             $args['color'] = null;
         }
 
+        $args['--allow-root'] = null;
+
         foreach ($args as $name => $value) {
             if (is_int($name)) { // positional argument
                 $cliCommand .= " " . ProcessUtils::escapeshellarg($value);

--- a/plugins/versionpress/src/Cli/VPCommandUtils.php
+++ b/plugins/versionpress/src/Cli/VPCommandUtils.php
@@ -23,6 +23,7 @@ class VPCommandUtils
             $args['color'] = null;
         }
 
+        // For commands that were run under root - #1049
         $args['--allow-root'] = null;
 
         foreach ($args as $name => $value) {


### PR DESCRIPTION
Resolves #1049.

I think we can add the switch to all commands, no matter they were run under root or not. Commands running under standard user do not mind the `--allow-root` switch.
