### PR TITLE
Temp files in ZIP

### DIFF
--- a/plugins/versionpress/src/Utils/RequirementsChecker.php
+++ b/plugins/versionpress/src/Utils/RequirementsChecker.php
@@ -274,7 +274,7 @@ class RequirementsChecker
 
     private function tryAccessControlFiles()
     {
-        $securedUrl = site_url() . '/wp-content/plugins/versionpress/versionpress-nginx.conf';
+        $securedUrl = plugins_url('versionpress-nginx.conf', 'versionpress/versionpress.php');
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
         return @file_get_contents($securedUrl) === false; // intentionally @
     }

--- a/plugins/versionpress/src/Utils/RequirementsChecker.php
+++ b/plugins/versionpress/src/Utils/RequirementsChecker.php
@@ -274,7 +274,7 @@ class RequirementsChecker
 
     private function tryAccessControlFiles()
     {
-        $securedUrl = site_url() . '/wp-content/plugins/versionpress/temp/security-check.txt';
+        $securedUrl = site_url() . '/wp-content/plugins/versionpress/versionpress-nginx.conf';
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
         return @file_get_contents($securedUrl) === false; // intentionally @
     }

--- a/plugins/versionpress/temp/.gitignore
+++ b/plugins/versionpress/temp/.gitignore
@@ -1,5 +1,0 @@
-*
-!.gitignore
-!.htaccess
-!web.config
-!security-check.txt

--- a/plugins/versionpress/temp/security-check.txt
+++ b/plugins/versionpress/temp/security-check.txt
@@ -1,1 +1,0 @@
-If you see this, your webserver is not secured.


### PR DESCRIPTION
Resolves #1154 

We don't need the `temp` directory anymore: https://github.com/versionpress/versionpress/commit/6843b874b21fef3ea72f5e1958d40c871ecba213#diff-e8ccf25c798ea6d4068705426a027cdcR20

Security check in RequirementsChecker is now done against `versionpress-nginx.conf` (we need some non-interpreted text file).