### PR TITLE
ext-libs are Composer-locked, not updated on each run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -248,7 +248,7 @@ gulp.task('clean-build', false, ['zip'], function (cb) {
  * Installs Composer external libs.
  */
 gulp.task('composer-install-ext-libs', false, function () {
-    return composer('update', {cwd: './ext-libs', bin: 'composer', 'ignore-platform-reqs': true});
+    return composer({cwd: './ext-libs', bin: 'composer', 'ignore-platform-reqs': true});
 });
 
 /**


### PR DESCRIPTION
ext-libs versions are locked since https://github.com/versionpress/versionpress/pull/1227/commits/fa1f6d33309e0c54cf1ed2ba017c5ea3e79d01a0, the Gulp task has been updated to respect this and not update on each run.