### PR TITLE
VP is copied to a test site, no longer a read-only mount

### DIFF
--- a/plugins/versionpress/tests/docker-compose.yml
+++ b/plugins/versionpress/tests/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - 80:80
     volumes:
       - document-root:/var/www/html
-      - ..:/var/www/html/vp01/wp-content/plugins/versionpress:ro
     depends_on:
       - mysql
 
@@ -28,7 +27,6 @@ services:
     volumes:
       # Same volumes as in `wordpress`
       - document-root:/var/www/html
-      - ..:/var/www/html/vp01/wp-content/plugins/versionpress:ro
 
       # Project mounts
       - ..:/opt/project:ro


### PR DESCRIPTION
Ref: #1257 

The title says it all, just some experience from running a couple of tests:

- I've tried running `ActivationDeactivationTest` which was primarily blocked by the read-only approach and the tests ran. They failed on genuine Selenium issues like `Unable to locate element: .wrap form:nth-of-type(1) input#submit` which is probably due to a newer WordPress version and will be a separate PR.
- All End2End passed with the change.
- Sometimes, MySQL is not ready and tests fail with something like "cannot connect to MySQL server". The next run, when the docker-compose stack is up and running, passes fine.