### PR TITLE
Fix for `wp vp update-config` and mysterious quote character instead of empty string

### DIFF
--- a/plugins/versionpress/src/Cli/VPCommandUtils.php
+++ b/plugins/versionpress/src/Cli/VPCommandUtils.php
@@ -20,11 +20,12 @@ class VPCommandUtils
 
         // Colorize the output
         if (defined('WP_CLI') && WP_CLI && \WP_CLI::get_runner()->in_color()) {
-            $args['color'] = null;
+            // All additional args need to be prepended, see #1279
+            $args = ['color' => null] + $args;
         }
 
         // For commands that were run under root - #1049
-        $args['allow-root'] = null;
+        $args = ['allow-root' => null] + $args;
 
         foreach ($args as $name => $value) {
             if (is_int($name)) { // positional argument

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -1222,7 +1222,7 @@ class VPCommand extends WP_CLI_Command
 
     private function runVPInternalCommand($subcommand, $args = [], $cwd = null)
     {
-        $args = $args + ['require' => __DIR__ . '/vp-internal.php'];
+        $args = ['require' => __DIR__ . '/vp-internal.php'] + $args;
         return VPCommandUtils::runWpCliCommand('vp-internal', $subcommand, $args, $cwd);
     }
 


### PR DESCRIPTION


Resolves #1279 

This was a tricky issue. There's probably a Symfony Process bug that sometimes converts an empty string argument to a single quote character, see: https://github.com/symfony/symfony/issues/23455.

The fix is to try to ensure that the important $args are the last ones. For example, if the main $args are `"DB_COLLATE"` and `""`, all the other args like `--color` and `--allow-root` are now prepended so that the final command reads like `wp vp update-config --color --allow-root "DB_COLLATE" ""`. In this order, everything works.