### PR TITLE
More reliable removing `user.name` and `user.email` from local Git config

### DIFF
--- a/plugins/versionpress/src/Git/GitRepository.php
+++ b/plugins/versionpress/src/Git/GitRepository.php
@@ -90,13 +90,13 @@ class GitRepository
         $this->runShellCommand("git commit --file=%s", $tempCommitMessagePath);
         FileSystem::remove($tempCommitMessagePath);
 
-        if ($localConfigUserName === null) {
+        if (!$localConfigUserName) {
             $this->runShellCommand('git config --local --unset user.name');
         } else {
             $this->runShellCommand('git config --local user.name %s', $localConfigUserName);
         }
 
-        if ($localConfigUserEmail === null) {
+        if (!$localConfigUserEmail) {
             $this->runShellCommand('git config --local --unset user.email');
         } else {
             $this->runShellCommand('git config --local user.email %s', $localConfigUserEmail);


### PR DESCRIPTION
Resolves #1281 

[This](https://github.com/versionpress/versionpress/blob/8aa1e1f27ea18e596474d37432132632fb8b0d07/plugins/versionpress/src/Git/GitRepository.php#L84-L85) was returning an empty string instead of null on Windows under some circumstances. The fix is verified on both Windows and in Docker `Workflow` tests.