### PR TITLE
nginx redirect for /wp-json/ API endpoint

### DIFF
--- a/plugins/versionpress/versionpress-nginx.conf
+++ b/plugins/versionpress/versionpress-nginx.conf
@@ -1,3 +1,7 @@
+location ~ /wp-json/.*$ {
+    rewrite ^(.*)/wp-json/(.*)$ $1/?rest_route=/$2&$args permanent;
+}
+
 location ~* /wp-content/plugins/versionpress/admin/public/.*$ {
     allow all;
 }

--- a/plugins/versionpress/versionpress-nginx.conf
+++ b/plugins/versionpress/versionpress-nginx.conf
@@ -1,4 +1,4 @@
-location ~ /wp-json/.*$ {
+location ~* /wp-json/.*$ {
     rewrite ^(.*)/wp-json/(.*)$ $1/?rest_route=/$2&$args permanent;
 }
 


### PR DESCRIPTION
Redirect solves the 404 error for "/wp-json/" API Endpoint when other then Plain Permalinks are used.

It is more of a hack than fix, but it can be useful until the nice(r) Permalinks are available. 


