### PR TITLE
Fix for plugins that create some tables later, not while activating

### DIFF
--- a/plugins/versionpress/src/Database/TableSchemaStorage.php
+++ b/plugins/versionpress/src/Database/TableSchemaStorage.php
@@ -26,6 +26,10 @@ class TableSchemaStorage
     {
         $schemaFile = $this->getSchemaFile($table);
 
+        if ($this->database->get_var("SHOW TABLES LIKE '$table'") != $table) {
+            return;
+        }
+
         $tableDDL = $this->database->get_var("show create table `{$table}`", 1);
 
         if (!$tableDDL) {
@@ -43,12 +47,10 @@ class TableSchemaStorage
     {
         $schemaFile = $this->getSchemaFile($table);
 
-        if (!file_exists($schemaFile)) {
-            throw new \Exception("Schema for table '$table' not found");
+        if (file_exists($schemaFile)) {
+            $tableDDL = file_get_contents($schemaFile);
+            return str_replace(Storage::PREFIX_PLACEHOLDER, $this->database->prefix, $tableDDL);
         }
-
-        $tableDDL = file_get_contents($schemaFile);
-        return str_replace(Storage::PREFIX_PLACEHOLDER, $this->database->prefix, $tableDDL);
     }
 
     public function containsSchema($table)

--- a/plugins/versionpress/src/Synchronizers/Synchronizer.php
+++ b/plugins/versionpress/src/Synchronizers/Synchronizer.php
@@ -268,8 +268,10 @@ class Synchronizer
 
     private function createTable()
     {
-        $tableDDL = $this->tableSchemaStorage->getSchema($this->entityInfo->tableName);
-        $this->database->query($tableDDL);
+        if ($this->tableSchemaStorage->getSchema($this->entityInfo->tableName)) {
+            $tableDDL = $this->tableSchemaStorage->getSchema($this->entityInfo->tableName);
+            $this->database->query($tableDDL);
+        }
     }
 
     /**


### PR DESCRIPTION
This fix resolves the problem where plugin don't create all tables while activating, but tables exists in plugin definitions.