### PR TITLE
Updated docs page on Developer Preview

### DIFF
--- a/docs/content/en/getting-started/about-eap.md
+++ b/docs/content/en/getting-started/about-eap.md
@@ -128,7 +128,7 @@ In Morse Code, `-.-` means k.
 
 .
 
-Ok, there are people that use VersionPress in production or to power their workflows. However, be aware of a couple of important things:
+Ok, there are people that use VersionPress in production or to power their workflows. However, make sure you understand a couple of key points:
 
 - For actions that perform database merging (pull, undo, ...), all plugins on your site _must_ be compatible with VersionPress, otherwise the site integrity cannot be guaranteed. At this point, you will need to ensure this yourself and possibly write [plugin definitions](https://docs.versionpress.net/en/developer/plugin-support/).
 - You'll probably need to be a developer yourself, with good knowledge of Git, WordPress and debugging in general.

--- a/docs/content/en/getting-started/about-eap.md
+++ b/docs/content/en/getting-started/about-eap.md
@@ -2,6 +2,8 @@
 
 Currently, VersionPress is a _Developer Preview_ and **should not be used in production**. We really mean it: any bugs or plugin incompatibilities might mess up your database.
 
+If you're eager to start using better WordPress workflows today, you can check out [VersionPress.com](https://versionpress.com): a simplified take on database merging by the same team, with different set of trade-offs (not directly built on Git, not as powerful but much more compatible with real-world sites). Note that VersionPress.com is a hosted service, not a plugin.
+
 .
 
 .

--- a/docs/content/en/getting-started/about-eap.md
+++ b/docs/content/en/getting-started/about-eap.md
@@ -1,18 +1,142 @@
 # Developer Preview
 
-Currently, VersionPress is a **"Developer Preview"**. It can be tried on simpler sites for development purposes but it's not production-ready yet.
+Currently, VersionPress is a _Developer Preview_ and **should not be used in production**. We really mean it: any bugs or plugin incompatibilities might mess up your database.
 
-## Considerations
+.
 
-- A safe bet is to use VersionPress for testing / dev purposes only. Local, throw-away sites and workflows are ideal.
-- Production deployment is strongly discouraged but if you attempt it despite the warning, at least **<span style="color:red;">keep backup at all times</span>**.
-- Compatibility with WordPress plugins and themes is often problematic, see [3rd Party Integrations section](../integrations/index.md).
-- Compatibility with hosts is often problematic as Git and `proc_open()` are required on the server. See [Hosting](../integrations/hosts.md) and [System requirements](./installation-uninstallation.md).
-- Be familiar with WordPress and Git.
+.
 
-You can tell whether you are using a Developer Preview / Early Access release of VersionPress from the top admin bar.
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+Fun fact: An ant can live up to 29 years.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+In Morse Code, `-.-` means k.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+Ok, there are people that use VersionPress in production or to power their workflows. However, be aware of a couple of important things:
+
+- For actions that perform database merging (pull, undo, ...), all plugins on your site _must_ be compatible with VersionPress, otherwise the site integrity cannot be guaranteed. At this point, you will need to ensure this yourself and possibly write [plugin definitions](https://docs.versionpress.net/en/developer/plugin-support/).
+- You'll probably need to be a developer yourself, with good knowledge of Git, WordPress and debugging in general.
+- **<span style="color:red;">Keep backup at all times!</span>**
+
+Good luck and welcome to the dark side.
+
+---
 
 !!! note "Note on 'Early Access' and 'EAP'"
-    Between January 2015 and March 2016, VersionPress used to be available through the *Early Access Program (EAP)*. It was discontinued when VersionPress [moved to a fully open development model](https://blog.versionpress.net/2016/04/going-open-source/) in April 2016.
+    Between January 2015 and March 2016, VersionPress used to be available through an *Early Access Program (EAP)*. It was discontinued when VersionPress [moved to an open-source model](https://blog.versionpress.net/2016/04/going-open-source/) in April 2016.
 
-    Between April 2016 and May 2017, the term "Early Access" was used. We then switched to "Developer Preview" which better indicates the project status. See [issue #1201](https://github.com/versionpress/versionpress/issues/1201).
+    Between April 2016 and May 2017, the term _Early Access_ was used, eventually [replaced](https://github.com/versionpress/versionpress/issues/1201) by the current one.


### PR DESCRIPTION
No issue, small docs PR.

Made it clearer that developer preview should not be used in production, plus a mention of VersionPress.com as a production-ready alternative.

Also, I learned that ants can live for a very long time!