### PR TITLE
Fixed bug related to an error during pull/push when installed WPML plugin

### DIFF
--- a/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php
+++ b/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php
@@ -100,9 +100,14 @@ class AbsoluteUrlReplacer
 
                     $r = new \ReflectionObject($value);
                     $p = $r->getProperties();
-                    foreach ($p as $prop) {
-                        $prop->setAccessible(true);
-                        $prop->setValue($value, $this->replaceRecursively($prop->getValue($value), $replaceFn));
+                    if (get_class($value) != 'wpdb' && get_class($value) != 'mysqli' && get_class($value) != 'mysqli_result') {
+                        foreach ($p as $prop) {
+                            $prop->setAccessible(true);
+                            $newValue = $this->replaceRecursively($prop->getValue($value), $replaceFn);
+                            if (get_class($newValue) != 'wpdb' && get_class($newValue) != 'mysqli' && get_class($newValue) != 'mysqli_result') {
+                                $prop->setValue($value, $newValue);
+                            }
+                        }
                     }
                     return $value;
                 } else {


### PR DESCRIPTION
Resolves https://github.com/versionpress/support/issues/150

This pull request is a part of work required to make WPML plugin to work together with Versionpress.
To resolve the issue, I added the conditions to skip invoking method setValue() in case if class of the value is `wpdb` or `mysqli` or `mysqli_result`.
 
**Actual result**
1. Versionpress was successfully installed.
2. During an installation of plugin "WPML Multilingual Plugin" (https://wpml.org/) an error occurred.
Also an error occur when Versionpress is trying to push/pull changes. 

**Expected result**
Versionpress successfully activated and is able to push/pull changes. All WPML plugins also should works fine.

Feel free to comment or update my PR. I'm just trying to make it work with WPML plugin. 