### PR TITLE
openid_nonces vary by server so should be ignored

### DIFF
--- a/plugins/versionpress/.versionpress/schema.yml
+++ b/plugins/versionpress/.versionpress/schema.yml
@@ -150,6 +150,7 @@ option:
     - 'option_name: logged_in_key'
     - 'option_name: logged_in_salt'
     - 'option_name: theme_switched'
+    - 'option_name: openid_nonces'
     # All {$taxonomy}_children are also ignored - see filter `vp_entity_should_be_saved_option`
   ignored-columns:
     - option_id


### PR DESCRIPTION
openid_nonces are tied to the Wordpress site URL, so they shouldn't be handled by VersionPress

Resolves #

Write a paragraph or two about the proposed changes here.
