### PR TITLE
Ignore user_meta community-events-location

### DIFF
--- a/plugins/versionpress/.versionpress/schema.yml
+++ b/plugins/versionpress/.versionpress/schema.yml
@@ -104,6 +104,7 @@ usermeta:
     - 'meta_key: nav_menu_recently_edited'
     - 'meta_key: wporg_favorites'
     - 'meta_key: *dashboard_quick_press_last_post_id'
+    - 'meta_key: community-events-location'
   clean-cache:
     - user: user_id
 


### PR DESCRIPTION
community-events-location records the user's IP upon login; that's not useful information to store in version control.

Resolves #

Write a paragraph or two about the proposed changes here.
