### PR TITLE
#1369 - updating getMenuReference to return "terms" instead of "term_taxonomy"

### DIFF
--- a/plugins/versionpress/src/Database/VpidRepository.php
+++ b/plugins/versionpress/src/Database/VpidRepository.php
@@ -233,7 +233,7 @@ class VpidRepository
                                             and vpid.vp_id = UNHEX(\"{$postmeta['vp_post_id']}\")");
 
         if ($menuItemType === 'taxonomy') {
-            return 'term_taxonomy';
+            return 'terms';
         }
 
         if ($menuItemType === 'post_type') {


### PR DESCRIPTION
Resolves #1369 

This is a one liner to address the bug described in 1369.  With this change the INI file will contain a VP ID for "terms" instead of "term taxonomy".  This will align with the data Wordpress stores in the postmeta when a category navigation item is saved.

Here is a before/after comparison of the change as relates to the DB/INI data.

```
1. Add a Category to a menu in the admin area and save.
   Wordpress inserts has the following data in the DB:

wp_postmeta
+---------+---------+------------------------+------------+
| meta_id | post_id | meta_key               | meta_value |
+---------+---------+------------------------+------------+
| 4471    |  2547   | _menu_item_object_id   | 46         |
+---------+---------+------------------------+------------+

wp_terms
+---------+-----------------------+-----------------------+------------+
| term_id | name                  | slug                  | term_group |
+---------+-----------------------+-----------------------+------------+
|  46     | Menu Item A 	  | menu-item-a           |    0       |
+---------+-----------------------+-----------------------+------------+

Version Press creates an INI file with the following line which map to the DB entries listed below.
_menu_item_object_id#7F5025806A054EEE9E8B64C059537D00 = "A13572D635B847F6B7C5EEA228B9D33B"

vp_id
+----------------------------------+---------------+------+
| vp_id            		   | table         | id   |
+----------------------------------+---------------+------+
| 7F5025806A054EEE9E8B64C059537D00 | postmeta      | 4471 |
+----------------------------------+---------------+------+
| A13572D635B847F6B7C5EEA228B9D33B | term_taxonomy | 43   |
+----------------------------------+---------------+------+

2. Apply the changes to a new WP instance or initialize so the DB is created from the INI files and the resulting post meta will be.

+---------+---------+------------------------+------------+
| meta_id | post_id | meta_key               | meta_value |
+---------+---------+------------------------+------------+
| 4471    |  2547   | _menu_item_object_id   | 43         |
+---------+---------+------------------------+------------+

3. The "43" resolves to a random post tag in wp_terms and not the correct category. If the above is repeated with the modifications to getMenuReference the output would be the following:

INI FILE: _menu_item_object_id#7F5025806A054EEE9E8B64C059537D00 = "A3888D9C400A48B7BC37EAB771ACC8AA"

vp_id
+----------------------------------+---------------+------+
| vp_id            		   | table         | id   |
+----------------------------------+---------------+------+
| 7F5025806A054EEE9E8B64C059537D00 | postmeta      | 4471 |
+----------------------------------+---------------+------+
| A3888D9C400A48B7BC37EAB771ACC8AA | terms         | 46   |
+----------------------------------+---------------+------+

4. After applying changes or initializing the resulting post meta is:

wp_postmeta
+---------+---------+------------------------+------------+
| meta_id | post_id | meta_key               | meta_value |
+---------+---------+------------------------+------------+
| 4471    |  2547   | _menu_item_object_id   | 46         |
+---------+---------+------------------------+------------+

5. Menu displays correctly in both the admin and user facing UIs.
```