### PR TITLE
require_once the Wordpress includes

### DIFF
--- a/plugins/versionpress/src/Cli/vp-internal.php
+++ b/plugins/versionpress/src/Cli/vp-internal.php
@@ -49,10 +49,10 @@ class VPInternalCommand extends WP_CLI_Command
         $wpConfigPath = \WP_CLI\Utils\locate_wp_config();
         require_once $wpConfigPath;
 
-        require ABSPATH . WPINC . '/formatting.php';
-        require ABSPATH . WPINC . '/link-template.php';
-        require ABSPATH . WPINC . '/shortcodes.php';
-        require ABSPATH . WPINC . '/taxonomy.php';
+        require_once ABSPATH . WPINC . '/formatting.php';
+        require_once ABSPATH . WPINC . '/link-template.php';
+        require_once ABSPATH . WPINC . '/shortcodes.php';
+        require_once ABSPATH . WPINC . '/taxonomy.php';
 
         wp_plugin_directory_constants();
 


### PR DESCRIPTION
Using require can cause the files being included once to result in an error as it does on Wordpress 5.1.

Resolves #1374
