### PR TITLE
Upgrade to PHP_CodeSniffer and fix newly identified issues

### DIFF
--- a/plugins/versionpress/admin/inc/activate.php
+++ b/plugins/versionpress/admin/inc/activate.php
@@ -126,7 +126,7 @@ function _vp_show_progress_message($progressMessage, $forceDisplay = false)
             <p class="initialization-done">
                 Ouch. The initialization took too long and was terminated by the server.<br>Please increase <a href="http://php.net/manual/en/info.configuration.php#ini.max-execution-time" target="_blank">maximal execution time</a> and <a href="<?php admin_url('admin.php?page=versionpress/admin/index.php&init_versionpress'); ?>">try it again</a>.
             </p>
-        <?php
+            <?php
         }
         ?>
 

--- a/plugins/versionpress/admin/inc/admin.php
+++ b/plugins/versionpress/admin/inc/admin.php
@@ -68,7 +68,7 @@ if (!empty($error)) {
 $showWelcomePanel = get_user_meta(get_current_user_id(), VersionPressOptions::USER_META_SHOW_WELCOME_PANEL, true);
 
 if ($showWelcomePanel === "") {
-?>
+    ?>
 
     <div id="welcome-panel" class="welcome-panel">
 

--- a/plugins/versionpress/composer.lock
+++ b/plugins/versionpress/composer.lock
@@ -2105,16 +2105,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.0.1",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f9eaf037edf22fdfccf04cb0ab57ebcb1e166219"
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f9eaf037edf22fdfccf04cb0ab57ebcb1e166219",
-                "reference": "f9eaf037edf22fdfccf04cb0ab57ebcb1e166219",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
                 "shasum": ""
             },
             "require": {
@@ -2124,7 +2124,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -2152,7 +2152,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-06-14T01:23:49+00:00"
+            "time": "2018-12-19T23:57:18+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -115,12 +115,12 @@ class QueryLanguageUtils
                 // name and email
                 if (strpos($value, '@') && strpos($value, '<')) {
                     $query .= ' --author="^' . $value . '$"';
-                } // email only
-                else {
+                } else {
+                    // email only
                     if (strpos($value, '@')) {
                         $query .= ' --author="^.* <' . $value . '>$"';
-                    } // name only
-                    else {
+                    } else {
+                        // name only
                         $query .= ' --author="^' . $value . ' <.*>$"';
                     }
                 }


### PR DESCRIPTION
Upgrade to the latest PHP_CodeSniffer (3.4.0). `( cd plugins/versionpress && ./vendor/bin/phpcs --standard=ruleset.xml )` then fails due to formatting issues; so fix those issues.