### PR TITLE
Use php7.2 in Travis to be consistent with the docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: php
 php:
-  - 5.6
+  - 7.2
 
 branches:
   only: 


### PR DESCRIPTION
The docker images all use PHP 7.2, so for consistency at least, Travis should also use PHP 7.2.