### PR TITLE
/var/www/html in wordpress-for-tests should not be a volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     image: versionpress/wordpress:php7.2-apache
     ports:
       - "80:80"
-    volumes:
-      - ./dev-env/wp-for-tests:/var/www/html:z
     links:
       - mysql-for-tests:mysql
     working_dir: /var/www/html/wptest
@@ -73,7 +71,6 @@ services:
       PHP_IDE_CONFIG: serverName=VersionPress-tests
     volumes:
       # !!! This must be kept in sync with wordpress-cli-image/Dockerfile
-      - ./dev-env/wp-for-tests:/var/www/html:z
       - ./dev-env/test-logs:/var/opt/versionpress/logs:z
       - ./plugins/versionpress:/opt/versionpress:ro,z
       - ./ext-libs:/opt/ext-libs:ro,z


### PR DESCRIPTION
This directory is used for running tests; it is entirely ephemeral.

Also, having it as a volume causes the mkdir and chown in
./dev-env/wordpress-cli-image/Dockerfile
to not take effect (since the volume is mounted over
/var/www/html), resulting in the tests not being able to
write to /var/www/html since its not owned by www-data,
resulting in tests failing with this error:
```
Exception: Error executing cmd 'php '/tmp/wp-cli-latest-stable.phar' core download --path='/var/www/html/wptest' --version='4.9' --force --locale='en_US'' from working directory '/var/www/html/wptest':
Error: '/var/www/html/wptest/' is not writable by current user.
 in /opt/versionpress/tests/Automation/WpAutomation.php:621
```

Resolves #

Write a paragraph or two about the proposed changes here.
