### PR TITLE
Run cli as user 33:33 to match www-data from versionpress/wordpress:php7.2-apache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - wpcli-cache:/var/www/.wp-cli:z
     working_dir: /opt/versionpress/tests
     command: ../vendor/bin/phpunit --verbose --colors -c phpunit.xml --testdox-text /var/opt/versionpress/logs/testdox.txt
+    user: "33:33"
 
   tests-with-wordpress:
     image: versionpress/wordpress:cli
@@ -83,6 +84,7 @@ services:
     links:
       - selenium-hub
       - wordpress-for-tests
+    user: "33:33"
 
   selenium-hub:
     # Standalone Firefox is enough but could also be a full grid setup, hence the service name

--- a/plugins/versionpress/tests/End2End/Revert/RevertTest.php
+++ b/plugins/versionpress/tests/End2End/Revert/RevertTest.php
@@ -153,15 +153,15 @@ class RevertTest extends End2EndTestCase
         $commitHash = $gitRepository->getLastCommitHash();
         $sitePath = self::$testConfig->testSite->path;
 
-        VPCommandUtils::exec('sudo -u www-data git branch test', $sitePath);
+        VPCommandUtils::exec('git branch test', $sitePath);
         self::$wpAutomation->createOption('vp_option_master', 'foo');
-        VPCommandUtils::exec('sudo -u www-data git checkout test', $sitePath);
+        VPCommandUtils::exec('git checkout test', $sitePath);
         self::$wpAutomation->createOption('vp_option_test', 'foo');
-        VPCommandUtils::exec('sudo -u www-data git checkout master', $sitePath);
-        VPCommandUtils::exec('sudo -u www-data git config user.name test', $sitePath);
-        VPCommandUtils::exec('sudo -u www-data git config user.email test@example.com', $sitePath);
-        VPCommandUtils::exec('sudo -u www-data git merge test', $sitePath);
-        VPCommandUtils::exec('sudo -u www-data git branch -d test', $sitePath);
+        VPCommandUtils::exec('git checkout master', $sitePath);
+        VPCommandUtils::exec('git config user.name test', $sitePath);
+        VPCommandUtils::exec('git config user.email test@example.com', $sitePath);
+        VPCommandUtils::exec('git merge test', $sitePath);
+        VPCommandUtils::exec('git branch -d test', $sitePath);
 
         $commitAsserter = $this->newCommitAsserter();
 

--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -38,8 +38,6 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
         $wpAutomation->ensureTestSiteIsReady();
 
         FileSystem::mkdir(self::$cloneSiteConfig->path);
-        chown(self::$cloneSiteConfig->path, 'www-data');
-        chgrp(self::$cloneSiteConfig->path, 'www-data');
 
         $wpAutomation->runWpCliCommand('vp', 'clone', [
             'name' => self::$cloneSiteConfig->name,

--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -158,8 +158,8 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
         $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
         $wpAutomation->editOption('blogname', 'Blogname from original - conflict');
 
-        VPCommandUtils::exec('sudo -u www-data git config user.name test', self::$siteConfig->path);
-        VPCommandUtils::exec('sudo -u www-data git config user.email test@example.com', self::$siteConfig->path);
+        VPCommandUtils::exec('git config user.name test', self::$siteConfig->path);
+        VPCommandUtils::exec('git config user.email test@example.com', self::$siteConfig->path);
 
         $output = $wpAutomation->runWpCliCommand('vp', 'pull', ['from' => self::$cloneSiteConfig->name]);
 


### PR DESCRIPTION
On Debian, www-data:www-data is 33:33
On Alpine (which is what cli is based on), www-data:www-data is 82:82
Therefore, when Alpine and Debian interact, one has to change to match the other.

See https://github.com/docker-library/wordpress/issues/256 for details

Makes progress on #1383, Travis now gets further.