### PR TITLE
Run CLI image as UID 33 (Debian's "www-data")

### DIFF
--- a/dev-env/wordpress-cli-image/Dockerfile
+++ b/dev-env/wordpress-cli-image/Dockerfile
@@ -1,12 +1,8 @@
 FROM wordpress:cli
 
-# IMPORTANT: About users
-#
-# This image is Alpine-based but needs to interact with Debian-based WordPress image. The catch is
-# that "www-data" is a different UID on the two systems – 33 in Debian but 82 on Alpine Linux.
-#
-# To make everything work smoothly together, we explicitly use UID 33 here (which could also
-# be written as the 'xfs' user).
+# IMPORTANT: this image is Apline-based where www-data is UID 82 while in Debian-based WordPress image,
+# it's 33. Both will be reading and writing to `/var/www/html` so we'll be using UID 33 in this Dockerfile
+# to avoid any permission issues. See e.g. docker-library/wordpress#256.
 #
 # Never use www-data in this Dockerfile!
 
@@ -29,7 +25,7 @@ RUN apk add --no-cache $PHPIZE_DEPS \
     } >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Docker mounts all volumes as root (moby/moby#2259) but we'll be running as UID 33. As a workaround,
-# we're going to create all future mount points here.
+# we're going to create all mount points ahead of time.
 #
 # ! Make sure the list of folders matches volumes in `docker-compose-test.yml`.
 RUN set -ex; \

--- a/dev-env/wordpress-cli-image/Dockerfile
+++ b/dev-env/wordpress-cli-image/Dockerfile
@@ -1,5 +1,15 @@
 FROM wordpress:cli
 
+# IMPORTANT: About users
+#
+# This image is Alpine-based but needs to interact with Debian-based WordPress image. The catch is
+# that "www-data" is a different UID on the two systems – 33 in Debian but 82 on Alpine Linux.
+#
+# To make everything work smoothly together, we explicitly use UID 33 here (which could also
+# be written as the 'xfs' user).
+#
+# Never use www-data in this Dockerfile!
+
 ENV XDEBUG_VERSION 2.6.0
 
 # Switching to root first, `wordpress:cli` sets the user to www-data.
@@ -18,18 +28,16 @@ RUN apk add --no-cache $PHPIZE_DEPS \
         echo 'xdebug.profiler_enable=0'; \
     } >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-# Docker mounts all volumes as `root` while the parent image uses www-data.
-# This creates issues with file permissions, for example, WP-CLI cannot write
-# to a root-owned /var/www/.wp-cli. A workaround is to create all folders that
-# are going to become mount points here, see moby/moby#2259 for related discussion.
+# Docker mounts all volumes as root (moby/moby#2259) but we'll be running as UID 33. As a workaround,
+# we're going to create all future mount points here.
 #
-# ! Make sure the list of folders matches volumes in docker-compose.yml.
+# ! Make sure the list of folders matches volumes in `docker-compose-test.yml`.
 RUN set -ex; \
     for f in /var/www/html /var/www/.wp-cli /var/opt/versionpress/logs; \
     do \
       mkdir -p "$f"; \
-	  chown -R www-data:www-data "$f"; \
+	  chown -R 33:33 "$f"; \
     done
 
-# Set the final runtime user again
-USER www-data
+# Set the final runtime user
+USER 33

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -42,7 +42,6 @@ services:
       - wpcli-cache:/var/www/.wp-cli:z
     working_dir: /opt/versionpress/tests
     command: ../vendor/bin/phpunit --verbose --colors -c phpunit.xml --testdox-text /var/opt/versionpress/logs/testdox.txt
-    user: "33:33"
 
   tests-with-wordpress:
     image: versionpress/wordpress:cli
@@ -62,7 +61,6 @@ services:
     links:
       - selenium-hub
       - wordpress-for-tests
-    user: "33:33"
 
   selenium-hub:
     # Standalone Firefox is enough but could also be a full grid setup, hence the service name


### PR DESCRIPTION
The CLI image is based on Alpine where the www-data user is UID 82 while the main WordPress image is based on Debian where www-data stands for UID 33. This causes trouble as files to `/var/www/html` are attempted to being read and written by different UIDs, depending on whether it's the Apache web server or WP-CLI / our testing code.

PR https://github.com/versionpress/versionpress/pull/1388 fixed the user on the `docker-compose.yml` level but that caused [this portion of Dockerfile](https://github.com/versionpress/versionpress/blob/618813bf79d9c2dc63bf5ebef751c84c46323130/dev-env/wordpress-cli-image/Dockerfile#L21-L32) to become invalid. This PR moves the solution to the Dockerfile level – it explicitly uses "33" instead of "www-data".

Some related resources:

- https://github.com/docker-library/wordpress/issues/256
- https://github.com/docker-library/wordpress/issues/279
- https://github.com/docker-library/docs/pull/1284/commits/10ba46a559b0f8853660739ea03ed1f99d144226

(Work on this is part of #1389.)