### PR TITLE
Use digests for Docker images

### DIFF
--- a/dev-env/wordpress-cli-image/Dockerfile
+++ b/dev-env/wordpress-cli-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:cli
+FROM wordpress:cli@sha256:f8600f5df710c0973ed250e16c1286de7f8344cd8ce0dcba3779931010e956d4
 
 # IMPORTANT: this image is Apline-based where www-data is UID 82 while in Debian-based WordPress image,
 # it's 33. Both will be reading and writing to `/var/www/html` so we'll be using UID 33 in this Dockerfile

--- a/dev-env/wordpress-image/Dockerfile
+++ b/dev-env/wordpress-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.2-apache
+FROM wordpress:php7.2-apache@sha256:08c71170cdd4427d155906f8eb0e715768c133f836780c97b0e3cc3e7c1288e2
 
 # Install prerequisites for WP-CLI & VersionPress
 RUN apt-get update \

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
 
   wordpress-for-tests:
-    image: versionpress/wordpress:php7.2-apache
+    image: versionpress/wordpress:php7.2-apache@sha256:64b3c10adfef9ae65a140d5547d670d996c5c852b9a840c71a86a5be4f777fdc
     ports:
       - "80:80"
     volumes:
@@ -14,7 +14,7 @@ services:
       WORDPRESS_DB_PASSWORD: r00tpwd
 
   mysql-for-tests:
-    image: mysql:5.7
+    image: mysql:5.7@sha256:1590f2540fd87e39605686873fb10206da4cbd7e83df2bc4110abe9fb740699e
     ports:
       - "3306:3306"
     volumes:
@@ -24,7 +24,7 @@ services:
 
   # See `tests-with-wordpress` for a service that also starts WordPress.
   tests:
-    image: versionpress/wordpress:cli
+    image: versionpress/wordpress:cli@sha256:86fc95921f1ac48950ab593b0b970e9a98ad3b28c0b16c5c6007ea0fac2839e9
     environment:
       VP_DIR: /opt/versionpress
       PHP_IDE_CONFIG: serverName=VersionPress-tests
@@ -39,7 +39,7 @@ services:
     command: ../vendor/bin/phpunit --verbose --colors -c phpunit.xml --testdox-text /var/opt/versionpress/logs/testdox.txt
 
   tests-with-wordpress:
-    image: versionpress/wordpress:cli
+    image: versionpress/wordpress:cli@sha256:86fc95921f1ac48950ab593b0b970e9a98ad3b28c0b16c5c6007ea0fac2839e9
     environment:
       VP_DIR: /opt/versionpress
       PHP_IDE_CONFIG: serverName=VersionPress-tests
@@ -58,10 +58,10 @@ services:
 
   selenium-hub:
     # Standalone Firefox is enough but could also be a full grid setup, hence the service name
-    image: selenium/standalone-firefox
+    image: selenium/standalone-firefox@sha256:541e4d726136b3fbf0220c1feb4d3a76c577d302e77050f1191a0d5b3a029c10
 
   copy-files-to-host:
-    image: alpine
+    image: alpine@sha256:644fcb1a676b5165371437feaa922943aaf7afcfa8bfee4472f6860aad1ef2a0
     volumes:
       - wordpress-files:/tmp/wp
       - ./dev-env/wp-for-tests:/tmp/wp-copy

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -22,11 +22,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: r00tpwd
 
-  adminer:
-    image: adminer
-    ports:
-      - "8099:8080"
-
   # See `tests-with-wordpress` for a service that also starts WordPress.
   tests:
     image: versionpress/wordpress:cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
 
   wordpress:
-    image: versionpress/wordpress:php7.2-apache
+    image: versionpress/wordpress:php7.2-apache@sha256:64b3c10adfef9ae65a140d5547d670d996c5c852b9a840c71a86a5be4f777fdc
     ports:
       - "80:80"
     volumes:
@@ -15,7 +15,7 @@ services:
       WORDPRESS_DB_PASSWORD: r00tpwd
 
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7@sha256:1590f2540fd87e39605686873fb10206da4cbd7e83df2bc4110abe9fb740699e
     ports:
       - "3306:3306"
     volumes:
@@ -24,7 +24,7 @@ services:
       MYSQL_ROOT_PASSWORD: r00tpwd
 
   adminer:
-    image: adminer
+    image: adminer@sha256:0e245b5550d7710ebfe728e682804947e2edade4d7f3313e7066b4629b728c5c
     ports:
       - "8099:8080"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL",
   "scripts": {
     "init-dev": "ts-node scripts/init-dev.ts",
-    "refresh-dev": "git clean -fxd && npm i && docker-compose pull",
+    "refresh-dev": "git clean -fxd && npm i",
     "init-phpstorm": "ts-node scripts/init-phpstorm.ts",
     "build": "ts-node scripts/build.ts",
     "start": "docker-compose up -d wordpress",


### PR DESCRIPTION
Part of #1389 

The `docker-compose.yml` files now contain specific digests like this:

```yaml
services:
  wordpress:
    image: versionpress/wordpress:php7.2-apache@sha256:64b3c10adfef9ae65a140d5547d670d996c5c852b9a840c71a86a5be4f777fdc
```

Dockerfiles also lock specific versions:

```Dockerfile
FROM wordpress:cli@sha256:f8600f5df710c0973ed250e16c1286de7f8344cd8ce0dcba3779931010e956d4
```

This should lead to more predictable versions running on users' computers.

Implementation notes:

- `docker-compose config --resolve-image-digests` prints out docker-compose with digests resolved.
- Using `image:tag@sha` is a nice trick from [this article](https://renovatebot.com/blog/docker-mutable-tags) (that article is worth reading anyway!).
- (BTW, the article is by [Renovate](https://renovatebot.com), a tool that we should consider in the future.)