### PR TITLE
Docker Toolbox on Windows – notes

### DIFF
--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -185,8 +185,8 @@ If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop)
 If you need to use Docker Toolbox:
 
 - [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356) for ports 80, 3306 and 8099.
-- If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects` and _Folder Name_ is `c/Projects`. [Details](https://stackoverflow.com/a/32030385).
-- Start _Docker Quickstart Terminal_ which uses Git Bash – we want that.
+- If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects`, _Folder Name_ is `c/Projects`, check both "Auto-mount" and "Make Permanent" and restart the VM. [Details](https://stackoverflow.com/a/32030385).
+- Start _Docker Quickstart Terminal_ which uses Git Bash.
 - If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
 
 ### Disable antivirus software

--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -178,15 +178,16 @@ As noted in [Getting started](#getting-started), we only support Git Bash on Win
 
 Git Bash is generally an awesome shell, the only problems you might encounter are related to paths. For example, Docker messes with them and when you try to run `docker run --rm -it ubuntu /bin/bash`, you'll see an error like `C:/Program Files/Git/usr/bin/bash.exe: no such file or directory`. Docker prepends `C:/Program Files/Git` for some reason but you can [use this workaround](https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3) or use double slash like `//bin/bash`.
 
-### Docker for Windows
+### Docker Desktop vs. Docker Toolbox
 
-If you can, use [Docker for Windows](https://www.docker.com/docker-windows), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/). The experience will be generally smoother.
+If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/). The experience will be generally smoother.
 
 If you need to use Docker Toolbox:
 
-- Enable port forwarding in VirtualBox (especially for ports 80, 3306, 8080 and 8099), see [details](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356).
-- Docker Toolbox is slower, but you can try to adjust system performance in VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
-- Run Git Bash and Docker Quickstart Terminal as an Administrator to avoid potential problems (for example permissions and symlinks).
+1. [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356), especially for ports 80 and 3306.
+2. If you have the repo checked out in a folder _not_ under `C:\Users`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects` and _Folder Name_ is `c/Projects`. [Details](https://stackoverflow.com/a/32030385).
+3. Run _Docker Quickstart Terminal_ which uses Git Bash – we want that.
+4. If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
 
 ### Disable antivirus software
 

--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -184,7 +184,7 @@ If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop)
 
 If you need to use Docker Toolbox:
 
-- [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356), especially for ports 80 and 3306.
+- [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356) for ports 80, 3306 and 8099.
 - If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects` and _Folder Name_ is `c/Projects`. [Details](https://stackoverflow.com/a/32030385).
 - Start _Docker Quickstart Terminal_ which uses Git Bash – we want that.
 - If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.

--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -180,14 +180,14 @@ Git Bash is generally an awesome shell, the only problems you might encounter ar
 
 ### Docker Desktop vs. Docker Toolbox
 
-If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/). The experience will be generally smoother.
+If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) – the experience will be smoother.
 
 If you need to use Docker Toolbox:
 
-1. [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356), especially for ports 80 and 3306.
-2. If you have the repo checked out in a folder _not_ under `C:\Users`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects` and _Folder Name_ is `c/Projects`. [Details](https://stackoverflow.com/a/32030385).
-3. Run _Docker Quickstart Terminal_ which uses Git Bash – we want that.
-4. If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
+- [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356), especially for ports 80 and 3306.
+- If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects` and _Folder Name_ is `c/Projects`. [Details](https://stackoverflow.com/a/32030385).
+- Start _Docker Quickstart Terminal_ which uses Git Bash – we want that.
+- If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
 
 ### Disable antivirus software
 

--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -180,14 +180,18 @@ Git Bash is generally an awesome shell, the only problems you might encounter ar
 
 ### Docker Desktop vs. Docker Toolbox
 
-If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) – the experience will be smoother.
+If you can, use [Docker Desktop](https://www.docker.com/products/docker-desktop), not [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/). The experience will be smoother (for example, ports are forwarded by default) and also the performance is much better due to a more modern virtualization technology.
 
-If you need to use Docker Toolbox:
+!!! important "Performance is important"
+    You'll notice a big difference between Docker Desktop and Docker Toolbox, for example, [tests](testing.md) run 3-4× slower in Toolbox (10 vs. 40 minutes). You might also run into various timeouts, for example, `wp_remote_get()` has a default timeout of 5 seconds which might not be enough.
+
+    Note that it's generally hard to improve the performance of Toolbox, even if you give the virtual machine more CPUs and RAM, see [these results for tests](https://github.com/versionpress/versionpress/pull/1401#issuecomment-476004709).
+
+If you need to use Docker Toolbox because you have an older machine or OS, brace yourself and follow these steps:
 
 - [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356) for ports 80, 3306 and 8099.
 - If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects`, _Folder Name_ is `c/Projects`, check both "Auto-mount" and "Make Permanent" and restart the VM. [Details](https://stackoverflow.com/a/32030385).
 - Start _Docker Quickstart Terminal_ which uses Git Bash.
-- If the performance is not great, try adjusting VirtualBox settings. However, you can run into timeout issues in Workflow tests sometimes and exceed default value of 5 seconds in `wp_remote_get()` in End2End tests.
 
 ### Disable antivirus software
 

--- a/docs/content/en/developer/dev-setup.md
+++ b/docs/content/en/developer/dev-setup.md
@@ -191,7 +191,7 @@ If you need to use Docker Toolbox because you have an older machine or OS, brace
 
 - [Enable port forwarding in VirtualBox](https://stackoverflow.com/questions/42866013/docker-toolbox-localhost-not-working/45822356#45822356) for ports 80, 3306 and 8099.
 - If you have the repo checked out in a folder _not_ under `C:\Users\youruser`, add it as a shared folder in VirtualBox settings. For example, add a share where _Folder Path_ is `C:\Projects`, _Folder Name_ is `c/Projects`, check both "Auto-mount" and "Make Permanent" and restart the VM. [Details](https://stackoverflow.com/a/32030385).
-- Start _Docker Quickstart Terminal_ which uses Git Bash.
+- Feel free to use the default Docker Quickstart Terminal: it uses Git Bash which is good.
 
 ### Disable antivirus software
 


### PR DESCRIPTION
Part of #1389.

I'm verifying how `tests:full` run on Docker Toolbox for Windows, this PR documents the process.

See:

- My setup from clean Windows machine: https://github.com/versionpress/versionpress/pull/1403#issuecomment-473608973
- Updated docs: https://github.com/versionpress/versionpress/pull/1403/commits/a13ba8f96a0aa98cf5abe0047e45235778ce6367
