### PR TITLE
Fresh site setup before CloneMergeTest

### DIFF
--- a/plugins/versionpress/tests/Automation/WpAutomation.php
+++ b/plugins/versionpress/tests/Automation/WpAutomation.php
@@ -50,10 +50,13 @@ class WpAutomation
     }
 
     /**
+     * Sets up a site to a fresh state (previous files and the database are removed).
+     *
      * @param array $entityCounts {@see populateSite}
      */
     public function setUpSite($entityCounts = [])
     {
+        FileSystem::remove($this->siteConfig->path);
         if ($this->siteConfig->installationType === 'standard') {
             $this->prepareStandardWpInstallation();
         } elseif ($this->siteConfig->installationType === 'composer') {

--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -26,6 +26,13 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
         self::$siteConfig = self::$testConfig->testSite;
 
         self::$cloneSiteConfig = self::getCloneSiteConfig(self::$siteConfig);
+
+        // Currently, workflow tests only pass when they are run on a fresh WordPress install, see #1409. That's why
+        // we force a full setup here. In the future, just `$wpAutomation->ensureTestSiteIsReady` should be used.
+        $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
+        $wpAutomation->setUpSite();
+        $wpAutomation->copyVersionPressFiles();
+        $wpAutomation->initializeVersionPress();
     }
 
     /**
@@ -33,12 +40,9 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
      */
     public function cloneLooksExactlySameAsOriginal()
     {
-        $siteConfig = self::$siteConfig;
-        $wpAutomation = new WpAutomation($siteConfig, self::$testConfig->wpCliVersion);
-        $wpAutomation->ensureTestSiteIsReady();
-
         FileSystem::mkdir(self::$cloneSiteConfig->path);
 
+        $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
         $wpAutomation->runWpCliCommand('vp', 'clone', [
             'name' => self::$cloneSiteConfig->name,
             'dbprefix' => self::$cloneSiteConfig->dbTablePrefix,


### PR DESCRIPTION
As a temporary solution for #1409, CloneMergeTest does a full site setup before it runs.

With the workaround in place, the full test suite passes for me 🎉 🎉 🎉 

![Screenshot 2019-03-26 at 14 20 38](https://user-images.githubusercontent.com/101152/55000243-69e73f80-4fd2-11e9-973e-ea9e3d2a654e.png)

This PR also update the behavior of `WpAutomation::setUpSite` in https://github.com/versionpress/versionpress/commit/eaa3b1bbcff8bb93eaf331239a8bb019627d6953 – the method now deletes any previous files.