### PR TITLE
Exploring the test stack – small updates

### DIFF
--- a/docs/content/en/developer/testing.md
+++ b/docs/content/en/developer/testing.md
@@ -105,10 +105,12 @@ npm run tests -- --explore
 
 You can now inspect it:
 
-- The site is running at <http://wordpress-for-tests/wptest> – check `test-config.yml` for the login info. (You'll also need to update your hosts file so that `wordpress-for-tests` resolves to `127.0.0.1`.)
+- The site is running at <http://wordpress-for-tests/wptest>:
+    - Update your hosts file to contain `127.0.0.1  wordpress-for-tests`.
+    - Check `test-config.yml` for the login info.
 - Connect to the database via `mysql -u root -p` or Adminer which you can access by running `docker-compose run -d --service-ports adminer` and visiting <http://localhost:8099>. The database name is `mysql-for-wordpress`.
 - To inspect the site files or the logs, you have two options:
-    1. Run `docker-compose -f docker-compose-tests.yml run --rm tests sh` and use commands like `ls -ls /var/www/html/wptest` or `cd /var/www/html/wptest && git log` to explore the files. Type `exit` when finished.
+    1. Run `docker-compose -f docker-compose-tests.yml run --rm tests sh` and use commands like `ls -la /var/www/html/wptest` or `cd /var/www/html/wptest && git log` to explore the files. Type `exit` when finished.
     2. Run `npm run tests:copy-files-to-host` to copy files to your local filesystem. This will create two folders, `dev-env/wp-for-tests` and `dev-env/test-logs`, where you can conveniently use your local tools (editors, Git GUI clients, etc.). Note that this can be quite resource-intensive, for example, on Docker for Mac, this will overwhelm the system for several minutes.
 
 When you're done, clean up everything by running:

--- a/docs/content/en/developer/testing.md
+++ b/docs/content/en/developer/testing.md
@@ -119,7 +119,7 @@ When you're done, clean up everything by running:
 npm run tests:cleanup
 ```
 
-This will stop & remove containers, delete volumes and remove temporaray files under `dev-env`.
+This will stop & remove containers and delete temporary files in `dev-env`.
 
 ## Other tests
 

--- a/docs/content/en/developer/testing.md
+++ b/docs/content/en/developer/testing.md
@@ -100,7 +100,7 @@ Currently, the default worker is WP-CLI and the only way to switch workers is to
 The Docker containers are stopped when tests finish running but the data is kept in Docker volumes. You can start the WordPress site again via:
 
 ```
-docker-compose -f docker-compose-tests.yml up -d wordpress-for-tests mysql-for-tests
+npm run tests -- --explore
 ```
 
 You can now inspect it:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "stop-and-cleanup": "docker-compose down -v && rm -rf dev-env/wp",
     "tests:unit": "node -r ./scripts/node_modules/ts-node/register scripts/run-tests.ts --testsuite Unit",
     "tests": "node -r ./scripts/node_modules/ts-node/register scripts/run-tests.ts",
-    "tests:cleanup": "docker-compose -f docker-compose-tests.yml down -v && rm -rf dev-env/wp-for-tests dev-env/test-logs",
+    "tests:cleanup": "docker-compose -f docker-compose-tests.yml down && rm -rf dev-env/wp-for-tests dev-env/test-logs",
     "tests:copy-files-to-host": "rm -rf dev-env/wp-for-tests dev-env/test-logs && docker-compose -f docker-compose-tests.yml run --rm copy-files-to-host",
     "build-images": "npm-run-all -s _build-image-*",
     "_build-image-wp": "docker build --pull -t versionpress/wordpress:php7.2-apache dev-env/wordpress-image",

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -11,6 +11,7 @@ const args = arg(
     '--help': Boolean,
     '--testsuite': String,
     '-c': String,
+    '--explore': Boolean,
     '-h': '--help',
   },
   { permissive: true }
@@ -28,6 +29,7 @@ if (args['--help']) {
                         or --stop-on-failure
 
   Non-PHPUnit options
+    --explore           Start containers to explore test results
     -h, --help          Show help
 
   Examples
@@ -35,6 +37,11 @@ if (args['--help']) {
     $ run-tests -c phpunit.custom.xml
     $ run-tests --testsuite End2End --filter OptionsTest
 `);
+  process.exit();
+}
+
+if (args['--explore']) {
+  startWPSite();
   process.exit();
 }
 
@@ -48,13 +55,7 @@ if (withWordPress) {
   utils.printTaskHeading('Cleaning up Docker containers and volumes...');
   shell.exec(`${dc} down -v`, { cwd: repoRoot });
 
-  utils.printTaskHeading('Starting MySQL...');
-  shell.exec(`${dc} up -d mysql-for-tests`, { cwd: repoRoot });
-  shell.exec(wait('mysql-for-tests:3306'), { cwd: repoRoot });
-
-  utils.printTaskHeading('Starting WordPress...');
-  shell.exec(`${dc} up -d wordpress-for-tests`, { cwd: repoRoot });
-  shell.exec(wait('wordpress-for-tests:80'), { cwd: repoRoot });
+  startWPSite();
 }
 
 utils.printTaskHeading('Running tests...');
@@ -76,4 +77,14 @@ shell.exec(
 if (withWordPress) {
   utils.printTaskHeading('Stopping containers...');
   shell.exec(`${dc} down`, { cwd: repoRoot });
+}
+
+function startWPSite() {
+  utils.printTaskHeading('Starting MySQL...');
+  shell.exec(`${dc} up -d mysql-for-tests`, { cwd: repoRoot });
+  shell.exec(wait('mysql-for-tests:3306'), { cwd: repoRoot });
+
+  utils.printTaskHeading('Starting WordPress...');
+  shell.exec(`${dc} up -d wordpress-for-tests`, { cwd: repoRoot });
+  shell.exec(wait('wordpress-for-tests:80'), { cwd: repoRoot });
 }


### PR DESCRIPTION
Part of #1389

I wanted to get rid of the very slow copying of files between Docker volumes and the host OS (`npm run tests:copy-files-to-host`) via Samba as mentioned here: https://github.com/versionpress/versionpress/issues/1389#issuecomment-471550657. However, I couldn't make it work and it seems quite complex, see e.g. [this Reddit post](https://www.reddit.com/r/docker/comments/ai6cqr/please_help_me_with_the_dpersonsamba_container/).

So this PR is only about small improvements like introducing a new `--explore` option to `run-tests.ts` and updating the documentation.

One change in behavior is that `npm run tests:cleanup` now keep volumes. This has the advantage that `npm run tests -- --explore` can be run again when necessary; volumes are cleaned up when tests start. See https://github.com/versionpress/versionpress/commit/d58676de52319de380379fd53a65dfb98acfa2f1.