### PR TITLE
Fix markdownlint violation in docs/content/en/troubleshooting/iis.md

### DIFF
--- a/docs/content/en/troubleshooting/iis.md
+++ b/docs/content/en/troubleshooting/iis.md
@@ -13,6 +13,7 @@ This seems to be happening for a cascade of reasons:
 1. Symfony internally uses [`proc_open()`](http://php.net/manual/en/function.proc-open.php) and for some reason, IIS spawns the processes created by `proc_open()` [under a different user](http://stackoverflow.com/q/33481246/21728) than PHP standard user.
 2. Because of a [PHP bug on Windows](https://github.com/symfony/process/blob/319794f611bd8bdefbac72beb3f05e847f8ebc92/Pipes/WindowsPipes.php#L90), Symfony\Process cannot read the process output directly and stores it to some temporary file first. It chooses to store it into the [`sys_get_temp_dir()`](http://php.net/manual/en/function.sys-get-temp-dir.php) directory.
 3. If this directory doesn't have write permission for the user used for `proc_open()`, VersionPress cannot read the Git output. It will look this strange on the [system info page](./system-info-page.md):
+
     ```php
     array (
         'git-binary-as-configured' => 'C:/Program Files (x86)/Git/bin/git.exe',


### PR DESCRIPTION
@borekb simple change so markdownlint passes