### PR TITLE
Have Travis run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
 
 install:
   - npm ci
-  - npm run init-dev
 
 before_script:
   - sudo /etc/init.d/mysql stop # Travis runs mysql by default and our docker tests want the mysql port (3306), so stop mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,36 @@ sudo: false
 language: php
 php:
   - 7.2
-
-branches:
-  only: 
-    - master
-
+services:
+  - docker
+addons:
+  apt:
+    packages:
+      - docker-ce
 cache:
   directories:
     - $HOME/.composer/cache
-
+    - $HOME/docker
+    - $HOME/.npm
 before_install:
-  - git config --global github.accesstoken $GITHUB_OAUTH_TOKEN
-  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN --no-interaction
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - nvm install 8
+  - nvm use 8
+
+install:
+  - npm ci
+  - npm run init-dev
+
+before_script:
+  - sudo /etc/init.d/mysql stop # Travis runs mysql by default and our docker tests want the mysql port (3306), so stop mysql
 
 script:
-    cd plugins/versionpress && composer install && ./vendor/bin/phpcs --standard=ruleset.xml
+  - set -e
+  - npm run lint:markdown
+  - npm run lint:php
+  - npm run build-images
+  - npm run tests
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "_push-image-cli": "docker push versionpress/wordpress:cli",
     "get-image-digests": "node -r ./scripts/node_modules/ts-node/register scripts/get-dockerhub-digests.ts versionpress/wordpress",
     "postinstall": "(cd scripts && npm install) && npm run init-dev",
-    "lint:markdown": "markdownlint -i '{**/vendor/**,**/node_modules/**,ext-libs/**,dev-env/**}' ."
+    "lint:markdown": "markdownlint -i '{**/vendor/**,**/node_modules/**,ext-libs/**,dev-env/**}' .",
+    "lint:php": "./plugins/versionpress/vendor/bin/phpcs --standard=./plugins/versionpress/ruleset.xml"
   },
   "engines": {
     "node": ">= 8.11",


### PR DESCRIPTION
Issue: #1259

Travis will now run markdownlint, php codesniffer, build the docker images, and run the full tests.

With this change, VersionPress can now only merge PRs that have passing tests, ensuring that all tests always pass.

(This is a similar PR to #1381, after we have fixed the testing infrastructure in #1389 so that the tests actually pass.)