### PR TITLE
Fix `run-tests.ts`: return non-zero exit code when tests fail

### DIFF
--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -65,7 +65,7 @@ const customTestSuite = args['--testsuite'] ? `--testsuite ${args['--testsuite']
 const phpunitXml = args['-c'] ? `-c ${args['-c']}` : '-c phpunit.xml';
 const colorizeOutput = process.stdout.isTTY ? '--colors=always' : '';
 
-shell.exec(
+const result = shell.exec(
   `${dc} run --rm ${containerToUse} ../vendor/bin/phpunit ${phpunitXml} ${customTestSuite} ${colorizeOutput} ${args._.join(
     ' '
   )}`,
@@ -78,6 +78,8 @@ if (withWordPress) {
   utils.printTaskHeading('Stopping containers...');
   shell.exec(`${dc} down`, { cwd: repoRoot });
 }
+
+process.exit((result as shell.ExecOutputReturnValue).code);
 
 function startWPSite() {
   utils.printTaskHeading('Starting MySQL...');


### PR DESCRIPTION
An issue discovered in #1421. The `run-tests.ts` script now correctly forwards the exit code from the tests. Previously, the TypeScript script always returned `0` even if the tests failed – visually, the output was correct but Travis didn't see the build as failing.

A quick way to test this is to run `npm run tests:unit` with some unit test artificially failing. Before 7bd2f40, the exit code (`echo $?`) is zero, after it, it's `1`.
