### PR TITLE
Updated docs on development process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Generally:
 3. Push the branch, open a pull request.
 4. The core team will review it and work with you if necessary.
 5. PR will be merged.
-6. :tada:
+6. 🎉
 
 Learn more about [our development process](docs/content/en/developer/development-process.md) and [set up your local development environment](docs/content/en/developer/dev-setup.md).
 

--- a/docs/content/en/developer/development-process.md
+++ b/docs/content/en/developer/development-process.md
@@ -4,29 +4,33 @@ If you want to contribute, this is an overview of how we manage the project.
 
 ## Workflow on GitHub
 
-All usually starts with a [GitHub issue](https://github.com/versionpress/versionpress/issues) – someone reports a bug or requests a feature.
-
-The issue is [labeled](https://github.com/versionpress/versionpress/labels) and put to a certain [milestone](https://github.com/versionpress/versionpress/milestones) if we have a rough idea when we'd like to work on it. [GitHub projects](https://github.com/versionpress/versionpress/projects) are then used to track the issues' progress.
+All usually starts with a [GitHub issue](https://github.com/versionpress/versionpress/issues) which is [labeled](https://github.com/versionpress/versionpress/labels) and put to a certain [milestones](https://github.com/versionpress/versionpress/milestones). [GitHub projects](https://github.com/versionpress/versionpress/projects) are used to more granularly track issue states.
 
 [Pull requests](https://github.com/versionpress/versionpress/pulls) implement the functionality. We use [the GitHub flow](https://guides.github.com/introduction/flow/):
 
 ![GitHub Flow](https://guides.github.com/activities/hello-world/branching.png)
 
-If you're contributing, please note the following:
+Some guidelines:
 
-- We appreciate small and focused commits with [good commit messages](https://chris.beams.io/posts/git-commit/).
-- Base your branch on `master` and name it `123-some-feature` where `123` is an issue reference.
-- Use merging, not rebasing. More broadly, never overwrite _published_ commits by rebasing, squashing or force-pushing them.
-
-Feel free to open a pull request early to gather feedback. When the development is done, please update the PR description to be a good overview of the change for anyone reading it in the future.
+- Name branches `123-some-feature` where `123` is an issue reference.
+- Never force-push or otherwise amend published commits. For example, don't rebase or squash commits.
+- Feel free to open a pull request early to gather feedback.
+- When the development is done, please update the PR description to be a good overview of the change for anyone reading it in the future.
 
 ## Release process
 
-### Version numbers
+It slightly evolves over time, it's best to find the most recent [release issue](https://github.com/versionpress/versionpress/labels/release) and start from there. General steps will involve:
 
-We bump major version with every release like browsers do, so you'll typically see a sequence like `2.0` → `3.0` → `3.0.1` (a bugfix release) → `4.0` etc.
+- Writing [release notes](#release-notes).
+- Preparing a build.
+- Publishing a GitHub release.
+- Announcing the release.
 
-Major versions typically go through alphas and betas which are tagged e.g. `4.0-beta2`.
+### Release versioning
+
+We use semver-like version numbers but the versioning is more like what web browsers do, i.e., bump major versions pretty frequently. We barely use minor versions so a typical sequence might look like this:
+
+`3.0` → `3.0.1` → `4.0-alpha` → `4.0-beta` → `4.0` etc.
 
 ### Release notes
 

--- a/docs/content/en/developer/development-process.md
+++ b/docs/content/en/developer/development-process.md
@@ -4,34 +4,39 @@ If you want to contribute, this is an overview of how we manage the project.
 
 ## Workflow on GitHub
 
-All usually starts with a [GitHub issue](https://github.com/versionpress/versionpress/issues) which is [labeled](https://github.com/versionpress/versionpress/labels) and put to a certain [milestones](https://github.com/versionpress/versionpress/milestones). [GitHub projects](https://github.com/versionpress/versionpress/projects) are used to more granularly track issue states.
+All usually starts with a [GitHub issue](https://github.com/versionpress/versionpress/issues) which is [labeled](https://github.com/versionpress/versionpress/labels) and put to a certain [milestone](https://github.com/versionpress/versionpress/milestones). [GitHub projects](https://github.com/versionpress/versionpress/projects) are used to more granularly track issue states.
 
 [Pull requests](https://github.com/versionpress/versionpress/pulls) implement the functionality. We use [the GitHub flow](https://guides.github.com/introduction/flow/):
 
 ![GitHub Flow](https://guides.github.com/activities/hello-world/branching.png)
 
-Some guidelines:
+Guidelines we follow:
 
-- Name branches `123-some-feature` where `123` is an issue reference.
-- Never force-push or otherwise amend published commits. For example, don't rebase or squash commits.
-- Feel free to open a pull request early to gather feedback.
-- When the development is done, please update the PR description to be a good overview of the change for anyone reading it in the future.
+- Branches are commonly named `123-some-feature` where `123` references an issue.
+- We never force-push or otherwise amend published commits, for example, we don't rebase or squash commits. Work-in-progress commits are absolutely fine.
+- It's often useful to open a pull request early so that it can be discussed.
+- When the development is done, we try to update the PR description so that it's a good overview of the change for anyone reading it in the future.
 
 ## Release process
 
-It slightly evolves over time, it's best to find the most recent [release issue](https://github.com/versionpress/versionpress/labels/release) and start from there. General steps will involve:
+It evolves over time, it's best to find the most recent [release issue](https://github.com/versionpress/versionpress/labels/release) and start from there. General steps involve:
 
-- Writing [release notes](#release-notes).
+- [Writing release notes](#release-notes).
 - Preparing a build.
 - Publishing a GitHub release.
 - Announcing the release.
 
 ### Release versioning
 
-We use semver-like version numbers but the versioning is more like what web browsers do, i.e., bump major versions pretty frequently. We barely use minor versions so a typical sequence might look like this:
+We use semver-like versioning with several differences:
+
+- If there's no patch version yet, we simply call it `X.0` instead of `X.0.0`.
+- We bump major versions frequently and don't use minor versions too much.
+
+A sequence of releases might look like this:
 
 `3.0` → `3.0.1` → `4.0-alpha` → `4.0-beta` → `4.0` etc.
 
-### Release notes
+### Writing release notes
 
 Release notes are primarily written in `docs/content/en/release-notes` and [published here](http://docs.versionpress.net/en/release-notes/). They are also copied to [GitHub releases](https://github.com/versionpress/versionpress/releases) with some slight formatting modifications.

--- a/docs/content/en/developer/development-process.md
+++ b/docs/content/en/developer/development-process.md
@@ -1,97 +1,33 @@
 # Development Process
 
-Here is a set of tools and approaches we use during VersionPress development.
+If you want to contribute, this is an overview of how we manage the project.
 
-## Overview
+## Workflow on GitHub
 
-[**Issues**](https://github.com/versionpress/versionpress/issues) are the most important tool to plan and manage almost everything around VersionPress. They are described in more detail in a [separate section below](#issues).
+All usually starts with a [GitHub issue](https://github.com/versionpress/versionpress/issues) – someone reports a bug or requests a feature.
 
-[**Milestones**](https://github.com/versionpress/versionpress/milestones) are used to assign issues to major releases like 4.0 or 5.0 (we don't use minor releases like 4.1 or 4.2, see [below](#release-versioning)).
+The issue is [labeled](https://github.com/versionpress/versionpress/labels) and put to a certain [milestone](https://github.com/versionpress/versionpress/milestones) if we have a rough idea when we'd like to work on it. [GitHub projects](https://github.com/versionpress/versionpress/projects) are then used to track the issues' progress.
 
-[**Projects**](https://github.com/versionpress/versionpress/projects) are then used for more granular planning, e.g., to assign issues to various alpha, beta or final releases.
-
-!!! note "Backlog"
-    Issues not assigned to any milestone are in a backlog – we want to do them one day but there are no immediate plans.
-
-[**Pull requests**](https://github.com/versionpress/versionpress/pulls) implement issues. Commonly, a piece of functionality starts as an issue but quickly transitions into a PR where most of the technical discussion happens. In other words, issues are the original ideas of how to improve or fix something, PR's are how it was actually done.
-
-## Development workflow
-
-We use the [GitHub flow](https://guides.github.com/introduction/flow/):
+[Pull requests](https://github.com/versionpress/versionpress/pulls) implement the functionality. We use [the GitHub flow](https://guides.github.com/introduction/flow/):
 
 ![GitHub Flow](https://guides.github.com/activities/hello-world/branching.png)
 
-Some tips:
+If you're contributing, please note the following:
 
-- Development setup is described in [dev-setup.md](dev-setup.md).
-- Branches are commonly named `<issue_number>-<short_description>`, e.g., `123-row-filtering`.
-- All branches start from `master`.
-- We care about small and focused commits with good commit messages.
-- Pull request should contain a link to the parent issue (if applicable) and a summary of the change. Every pull request is reviewed.
+- We appreciate small and focused commits with [good commit messages](https://chris.beams.io/posts/git-commit/).
+- Base your branch on `master` and name it `123-some-feature` where `123` is an issue reference.
+- Use merging, not rebasing. More broadly, never overwrite _published_ commits by rebasing, squashing or force-pushing them.
 
-## Issues
+Feel free to open a pull request early to gather feedback. When the development is done, please update the PR description to be a good overview of the change for anyone reading it in the future.
 
-Some more details on our issues:
+## Release process
 
-### Labels
+### Version numbers
 
-We use [these labels](https://github.com/versionpress/versionpress/labels) to tag GitHub issues:
+We bump major version with every release like browsers do, so you'll typically see a sequence like `2.0` → `3.0` → `3.0.1` (a bugfix release) → `4.0` etc.
 
-- Issue type:
-    - `bug` – a major bug has an additional `major` label
-    - `feature` – something new in a release
-    - `improvement` – an improvement of an existing feature
-    - `task`
-    - `question`
-    - `support` – issue that should have been opened in the [support repo](https://github.com/versionpress/support)
-- Importance:
-    - `minor`
-    - `major` – only used with bugs, see above
-    - `significant` – used to highlight issues that are worth mentioning in release notes or otherwise significant
-- Scopes (areas of work):
-    - `scope: core` – the core VersionPress functionality like tracking actions, creating Git commits etc.
-    - `scope: workflows` – things like cloning, pulling, pushing, etc.
-    - `scope: gui` – issue for the 'frontend' React app and other UI things
-    - `scope: tests`
-    - `scope: dev-infrastructure` – IDE settings, build scripts, etc.
-    - `scope: docs`
-    - `scope: integrations` – integrations with WordPress plugins, themes, hosts etc.
-    - Some historic labels like `scope: website`, `scope: blog` etc. Those are commonly managed via separate repositories now.
-- Effort, roughly:
-    - `size: xs` – 1 to 2 hours
-    - `size: s` – about half a day
-    - `size: m` – day or two
-    - `size: l` – three to five days
-    - `size: xl` – multiple weeks
-- Resolution:
-    - Most issues are just closed when done without any additional label. They are also moved to the _Done_ column in a GitHub project.
-    - `duplicate` – issue is resolved by some other ticket
-    - `invalid` – incorrectly reported, not an actual bug etc.
-    - `obsolete` – no longer valid
-    - `won't fix` – we don't plan to implement this
-- Other:
-    - `needs-migration` – such issues change a storage format and require migration between two VersionPress versions. (Currently, we do not have migrations which means that if a release contains one or more `needs-migration` issues, full deactivation and re-activation is required. See [#275](https://github.com/versionpress/versionpress/issues/275).)
-    - `WP 4.7` – compatibility with WordPress 4.7.
-    - `plugin-support` – issues implementing the plugin support in VersionPress 4.0.
+Major versions typically go through alphas and betas which are tagged e.g. `4.0-beta2`.
 
-### Note on imported issues 1..522
+### Release notes
 
-In the early days, we used JIRA and the Czech language to track the project (*bad* decision in retrospect 😅), with the earliest issues not even up to the common standards as we were a team of two and discussed many things face to face.
-
-In October 2015, we decided to move to GitHub and take the project **history** with us, both on the repo level (no "initial commit" with thousands of lines of code) and the issues. The issues were not fun as we needed to write a migration script, fight the GitHub API limitations (e.g., dates cannot be set properly) and eventually translate the issues to English. But there's valuable information in there so we didn't want to throw that part of the project history away.
-
-Still, please consider **issues #1 through #522 "quick and dirty"** – the translation may be poor, the issues may not explain everything in detail, etc.
-
-For newer issues, we try to make them useful and high-quality; they are one of our key artifacts.
-
-## Release versioning
-
-We bump major version with every release like browsers do so VersionPress quickly advances from `4.0` to `5.0` to `6.0` etc. We do not use minor versions like `4.1` or `4.2`. We do, however, use patch releases like `4.0.1` or `4.0.2`.
-
-Preview versions are marked e.g. `4.0-alpha` or `4.0-beta2`, as per [semver](http://semver.org/).
-
-## Branching model
-
-The current release being worked on is **`master`**. All tests should be passing before any code is merged to `master`.
-
-There are **long-running branches** for every release named `1.x`, `2.x` etc. For bug fixes, always merge from older to newer, e.g., `1.x` -> `2.x` -> `master`, never the other way around, see [this blog post](http://blogs.atlassian.com/2013/11/the-essence-of-branch-based-workflows/). With that being said, during the Developer Preview program, we mostly care about the "latest and greatest" only.
+Release notes are primarily written in `docs/content/en/release-notes` and [published here](http://docs.versionpress.net/en/release-notes/). They are also copied to [GitHub releases](https://github.com/versionpress/versionpress/releases) with some slight formatting modifications.

--- a/docs/content/en/release-notes/index.md
+++ b/docs/content/en/release-notes/index.md
@@ -1,21 +1,3 @@
 # Release Notes
 
-The current release is **[3.0](3.0.md)**, released on 28 Apr 2016, and it is an [Early Access release](../getting-started/about-eap.md). VersionPress can be obtained via the main **[versionpress.net](https://versionpress.net/)** site.
-
-## Release versioning
-
-VersionPress releases are marked so that it's easy to understand what to expect of them. Here is a couple of rules we follow:
-
-- VersionPress generally **bumps a major version with every release**, so while WordPress uses a sequence like `4.1` → `4.2` → `4.3` etc., we generally use `4.0` → `5.0` → `6.0` etc., similarly to modern web browsers.
-- **Minor releases**, e.g., `4.1`, with minor feature changes can happen but we generally aim to avoid them.
-- **Patch releases** use the third segment of version identifier, e.g., `4.0.1`. We aim to avoid them too :-)
-- **Preview versions** are marked with labels like `4.0-alpha1`, `4.0-beta1`, `4.0-rc2` and similar. Pre-release names have their well-defined meaning:
-    - **Alpha** means that we are not feature complete yet and that there *will* be bugs, possibly even severe ones. Never use an alpha release on a production site, with production database or generally with any data that you care for.
-    - **Beta** means most if not all features are complete and the stability is quite good, however, running such version in production is still strongly discouraged.
-    - **RC (Release Candidate)** is close to the final / stable version.
-
-Versions are compared and ordered by the same rules that [semver](http://semver.org/) uses – versions with two segments assume the ".0" at the end so 1.0 is effectively the same as 1.0.0.
-
-## Roadmap
-
-See [roadmap here](roadmap.md).
+Please choose a release in the sidebar or visit [GitHub releases](https://github.com/versionpress/versionpress/releases).


### PR DESCRIPTION
Issue: #1417 

When preparing for the 4.0-beta2 release #1373 , I went through our docs on the development / release process and updated them slightly. It's been mostly deleting stuff:

- [Labels are now self-documenting](https://github.blog/2018-02-22-label-improvements-emoji-descriptions-and-more/) on GitHub.
- Note on imported issues 1..522 has been moved to https://github.com/versionpress/versionpress/issues/787#issuecomment-477146942.
- Info about release versioning has been duplicated between `developer/development-process.md` and `release-notes/index.md`, I simplified the Release Notes homepage.