### PR TITLE
Add 4.0-beta2 release notes

### DIFF
--- a/docs/content/en/release-notes/4.0-beta2.md
+++ b/docs/content/en/release-notes/4.0-beta2.md
@@ -38,6 +38,7 @@ On a related note, **@pavelevap** is joining the project as an official maintain
 
 ### Pull requests
 
+[#1425](https://github.com/versionpress/versionpress/pull/1425) Add `--format markdown` option to the `changelog` tool<br>
 [#1424](https://github.com/versionpress/versionpress/pull/1424) Changelog script<br>
 [#1423](https://github.com/versionpress/versionpress/pull/1423) Update docs on development process ([#1417](https://github.com/versionpress/versionpress/issues/1417))<br>
 [#1422](https://github.com/versionpress/versionpress/pull/1422) Fix `run-tests.ts`: return non-zero exit code when tests fail<br>

--- a/docs/content/en/release-notes/4.0-beta2.md
+++ b/docs/content/en/release-notes/4.0-beta2.md
@@ -1,0 +1,96 @@
+# 4.0-beta2 Release Notes
+
+Maintenance release focusing on bug fixes and improvements of the dev / testing infrastructure.
+
+Released 15 April 2019.
+
+- [**Download**](https://github.com/versionpress/versionpress/releases/download/4.0-beta2/versionpress-4.0-beta2.zip)
+- [Installation instructions](https://docs.versionpress.net/en/getting-started/installation-uninstallation/)
+
+!!! warning "Developer Preview"
+    VersionPress is not production-ready, use it with care. [Learn more](../getting-started/about-eap.md).
+
+## Highlights
+
+The main changes since the previous beta are:
+
+- Several bugs have been fixed by contributors **@mkreckovic**, **@candrews**, **@lframnes**, **@x1024** and others.
+- Our extensive test suite now fully passes and tests run automatically on Travis thanks to a great work done by **@candrews**. In general, we invested in a dev / testing infrastructure to make future contributions easier.
+- **@iamlisaross** worked on modernizing our docs site and the results are awesome – each page is easily editable via GitHub, the dev topics like plugin support are published in the new "Developer" section, there is full text search now, etc. We [blogged about it](https://versionpress.com/blog/2018/06/updated-docs-site/).
+
+On a related note, **@pavelevap** is joining the project as an official maintainer and we hope to work on full Gutenberg compatibility next.
+
+## Full changelog
+
+### Noteworthy issues
+
+[#1259](https://github.com/versionpress/versionpress/issues/1259) Travis CI<br>
+[#1389](https://github.com/versionpress/versionpress/issues/1389) Improve Dockerized testing infrastructure<br>
+
+### Noteworthy pull requests
+
+[#1385](https://github.com/versionpress/versionpress/pull/1385) Fix merge driver on Debian-based systems ([#1384](https://github.com/versionpress/versionpress/issues/1384))<br>
+[#1324](https://github.com/versionpress/versionpress/pull/1324) Fix wrong SELECT and SHOW queries detection<br>
+[#1370](https://github.com/versionpress/versionpress/pull/1370) Make getMenuReference return "terms" instead of "term_taxonomy" ([#1369](https://github.com/versionpress/versionpress/issues/1369))<br>
+[#1368](https://github.com/versionpress/versionpress/pull/1368) Deploying docs site to Netlify ([#1367](https://github.com/versionpress/versionpress/issues/1367))<br>
+[#1334](https://github.com/versionpress/versionpress/pull/1334) Switch to MkDocs for documentation ([#1332](https://github.com/versionpress/versionpress/issues/1332))<br>
+[#1329](https://github.com/versionpress/versionpress/pull/1329) Dev setup updates – spring 2018<br>
+
+### Pull requests
+
+[#1424](https://github.com/versionpress/versionpress/pull/1424) Changelog script<br>
+[#1423](https://github.com/versionpress/versionpress/pull/1423) Update docs on development process ([#1417](https://github.com/versionpress/versionpress/issues/1417))<br>
+[#1422](https://github.com/versionpress/versionpress/pull/1422) Fix `run-tests.ts`: return non-zero exit code when tests fail<br>
+[#1415](https://github.com/versionpress/versionpress/pull/1415) Have Travis run tests ([#1259](https://github.com/versionpress/versionpress/issues/1259))<br>
+[#1418](https://github.com/versionpress/versionpress/pull/1418) Update frontend dependecies<br>
+[#1414](https://github.com/versionpress/versionpress/pull/1414) Fix markdownlint violation in `docs/content/en/troubleshooting/iis.md`<br>
+[#1411](https://github.com/versionpress/versionpress/pull/1411) Small updates of exploring the test WP site after tests have run<br>
+[#1410](https://github.com/versionpress/versionpress/pull/1410) Fresh site setup before CloneMergeTest (workaround) ([#1409](https://github.com/versionpress/versionpress/issues/1409))<br>
+[#1403](https://github.com/versionpress/versionpress/pull/1403) Docker Toolbox on Windows – notes ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1401](https://github.com/versionpress/versionpress/pull/1401) New `run-tests.ts`, making test runs more reliable ([#1389](https://github.com/versionpress/versionpress/issues/1389), [#1400](https://github.com/versionpress/versionpress/issues/1400))<br>
+[#1404](https://github.com/versionpress/versionpress/pull/1404) 'Scripts' project with its own `package.json`, deps update ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1399](https://github.com/versionpress/versionpress/pull/1399) Stop containers after tests ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1398](https://github.com/versionpress/versionpress/pull/1398) Use digests for Docker images ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1396](https://github.com/versionpress/versionpress/pull/1396) Use named volumes for tests ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1397](https://github.com/versionpress/versionpress/pull/1397) Run CLI image as UID 33 (Debian's "www-data") ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1395](https://github.com/versionpress/versionpress/pull/1395) Separate docker-compose files for dev and tests ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1394](https://github.com/versionpress/versionpress/pull/1394) Revert "Run tests in Travis" for now<br>
+[#1393](https://github.com/versionpress/versionpress/pull/1393) Minor docs updates around dev setup and testing ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1392](https://github.com/versionpress/versionpress/pull/1392) Docs: separate page on Testing ([#1389](https://github.com/versionpress/versionpress/issues/1389))<br>
+[#1388](https://github.com/versionpress/versionpress/pull/1388) Run CLI as user 33:33 to match Debian's www-data ([#1383](https://github.com/versionpress/versionpress/issues/1383))<br>
+[#1385](https://github.com/versionpress/versionpress/pull/1385) Fix merge driver on Debian-based systems ([#1384](https://github.com/versionpress/versionpress/issues/1384))<br>
+[#1381](https://github.com/versionpress/versionpress/pull/1381) Run tests in Travis ([#1259](https://github.com/versionpress/versionpress/issues/1259))<br>
+[#1379](https://github.com/versionpress/versionpress/pull/1379) Make sure the test-logs directory exists<br>
+[#1377](https://github.com/versionpress/versionpress/pull/1377) Upgrade to PHP_CodeSniffer and fix newly identified issues<br>
+[#1378](https://github.com/versionpress/versionpress/pull/1378) Use PHP 7.2 in Travis to be consistent with Docker images<br>
+[#1375](https://github.com/versionpress/versionpress/pull/1375) `require_once` for WordPress includes ([#1374](https://github.com/versionpress/versionpress/issues/1374))<br>
+[#1372](https://github.com/versionpress/versionpress/pull/1372) Update lockfile for npm 6.7<br>
+[#1371](https://github.com/versionpress/versionpress/pull/1371) Set the "z" option for Docker volumes<br>
+[#1324](https://github.com/versionpress/versionpress/pull/1324) Fix wrong SELECT and SHOW queries detection<br>
+[#1370](https://github.com/versionpress/versionpress/pull/1370) Make getMenuReference return "terms" instead of "term_taxonomy" ([#1369](https://github.com/versionpress/versionpress/issues/1369))<br>
+[#1368](https://github.com/versionpress/versionpress/pull/1368) Deploying docs site to Netlify ([#1367](https://github.com/versionpress/versionpress/issues/1367))<br>
+[#1358](https://github.com/versionpress/versionpress/pull/1358) Add VSCode settings<br>
+[#1353](https://github.com/versionpress/versionpress/pull/1353) Update frontend dependencies ([#1351](https://github.com/versionpress/versionpress/issues/1351))<br>
+[#1348](https://github.com/versionpress/versionpress/pull/1348) Use markdownlint for Markdown files<br>
+[#1349](https://github.com/versionpress/versionpress/pull/1349) Fix subheading nesting in `plugin-support.md`<br>
+[#1343](https://github.com/versionpress/versionpress/pull/1343) Updated docs page on Developer Preview<br>
+[#1342](https://github.com/versionpress/versionpress/pull/1342) Docs README small update<br>
+[#1340](https://github.com/versionpress/versionpress/pull/1340) Document `VP_WP_CLI_BINARY` setting<br>
+[#1341](https://github.com/versionpress/versionpress/pull/1341) Update intro section on Docker<br>
+[#1338](https://github.com/versionpress/versionpress/pull/1338) Fix frontend package vulnerabilities ([#1335](https://github.com/versionpress/versionpress/issues/1335))<br>
+[#1337](https://github.com/versionpress/versionpress/pull/1337) Update frontend dependecies ([#1335](https://github.com/versionpress/versionpress/issues/1335))<br>
+[#1334](https://github.com/versionpress/versionpress/pull/1334) Switch to MkDocs for documentation ([#1332](https://github.com/versionpress/versionpress/issues/1332))<br>
+[#1329](https://github.com/versionpress/versionpress/pull/1329) Dev setup updates – spring 2018<br>
+[#1318](https://github.com/versionpress/versionpress/pull/1318) Fix typo in activation message<br>
+[#1314](https://github.com/versionpress/versionpress/pull/1314) Add error when re-activating VP with WP-CLI ([#1313](https://github.com/versionpress/versionpress/issues/1313))<br>
+[#1310](https://github.com/versionpress/versionpress/pull/1310) Use WP 4.9 for test sites – part 2<br>
+[#1309](https://github.com/versionpress/versionpress/pull/1309) Make checkboxes for bulk update checkable ([#1308](https://github.com/versionpress/versionpress/issues/1308))<br>
+[#1307](https://github.com/versionpress/versionpress/pull/1307) Use WP 4.9 for test sites<br>
+
+### Direct commits to master
+
+[`77ad593c`](https://github.com/versionpress/versionpress/commit/77ad593c) Link to Gitter and support repo in ISSUE_TEMPLATE.md<br>
+[`84d3229e`](https://github.com/versionpress/versionpress/commit/84d3229e) Updated intro message to mention beta instead of alpha<br>
+[`8244d42a`](https://github.com/versionpress/versionpress/commit/8244d42a) Added link to announcement blog post<br>
+
+See [all issues and PRs resolved for 4.0-beta2](https://github.com/versionpress/versionpress/issues?utf8=%E2%9C%93&q=project%3Aversionpress%2Fversionpress%2F3+is%3Aclosed) or the [GitHub project](https://github.com/versionpress/versionpress/projects/3).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ pages:
   - Release Notes:
     - 'Release Notes Home': 'en/release-notes/index.md'
     - 'Roadmap': 'en/release-notes/roadmap.md'
+    - '4.0-beta2 Release Notes': 'en/release-notes/4.0-beta2.md'
     - '4.0-beta Release Notes': 'en/release-notes/4.0-beta.md'
     - '4.0-alpha1 Release Notes': 'en/release-notes/4.0-alpha1.md'
     - '3.0.2 Release Notes': 'en/release-notes/3.0.2.md'


### PR DESCRIPTION
Issue: #1373 

Using the `changelog` script for the first time.

Note that this PR will need to be merged before beta2 is released, making the full changelog in the release notes outdated by this single PR. So the common workflow will be to update the Markdown document post-release.