### PR TITLE
Capitalized values aren't handled correctly

### DIFF
--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -83,7 +83,7 @@ class QueryLanguageUtils
 
                 if ($isWildcard && preg_match(QueryLanguageUtils::tokensToRegex($valueTokens), $entity[$field])) {
                     return true;
-                } elseif (strval($entity[$field]) === $value) {
+                } elseif (strtolower(strval($entity[$field])) === strtolower($value)) {
                     return true;
                 }
 

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -83,7 +83,7 @@ class QueryLanguageUtils
 
                 if ($isWildcard && preg_match(QueryLanguageUtils::tokensToRegex($valueTokens), $entity[$field])) {
                     return true;
-                } elseif (strtolower(strval($entity[$field])) === strtolower($value)) {
+                } elseif (strtolower(strval($entity[$field])) === $value) {
                     return true;
                 }
 

--- a/plugins/versionpress/tests/Unit/EntityInfoTest.php
+++ b/plugins/versionpress/tests/Unit/EntityInfoTest.php
@@ -147,7 +147,6 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
         $entity = [
             'some_field' => 'value',
             'other_field' => 'b',
-            'capitalized_value_field' => 'qqq',
         ];
 
         $this->assertFalse($this->entityInfo->isIgnoredEntity($entity));

--- a/plugins/versionpress/tests/Unit/EntityInfoTest.php
+++ b/plugins/versionpress/tests/Unit/EntityInfoTest.php
@@ -19,6 +19,7 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
             ],
             'ignored-entities' => [
                 'some_field: value other_field: a',
+                'capitalized_value_field: VALUE',
                 'other_field: value'
             ],
             'ignored-columns' => [
@@ -70,6 +71,9 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
                 'other_field' => ['a'],
             ],
             [
+                'capitalized_value_field' => ['value'], // the value is lowercased
+            ],
+            [
                 'other_field' => ['value']
             ],
         ];
@@ -118,6 +122,20 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function ignoredEntityCapitalizedIsCorrectlyIdentified()
+    {
+        $entity = [
+            'some_field' => 'b',
+            'other_field' => 'a',
+            'capitalized_value_field' => 'VaLuE', // comparison must be case insensitive
+        ];
+
+        $this->assertTrue($this->entityInfo->isIgnoredEntity($entity));
+    }
+
+    /**
+     * @test
+     */
     public function commonEntityIsNotFalselyIdentifiedAsIgnored()
     {
         $entity = [
@@ -129,6 +147,7 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
         $entity = [
             'some_field' => 'value',
             'other_field' => 'b',
+            'capitalized_value_field' => 'qqq',
         ];
 
         $this->assertFalse($this->entityInfo->isIgnoredEntity($entity));


### PR DESCRIPTION
VersionPress doesn't correctly handled capitalized values in its schema configuration. The intent appears to be that comparison should be case insensitive, but that's not how it currently works.

For example, this configuration:
```
some-entity:
    ignored-entities:
        capitalized_value_field: VALUE
```

does not ignore this entity:
```
some-entity:
    capitalized_value_field: VALUE
```

and it should.