### PR TITLE
Clarify names of tests in EntityInfoTest

### DIFF
--- a/plugins/versionpress/tests/Unit/EntityInfoTest.php
+++ b/plugins/versionpress/tests/Unit/EntityInfoTest.php
@@ -97,8 +97,9 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function commonEntityIsNotFalselyIdentifiedAsFrequentlyWritten()
+    public function partialMatchIsNotFalselyIdentifiedAsFrequentlyWritten()
     {
+        // The rule is `'some_field: value other_field: a'` and the entity only partially matches it:
         $entity = [
             'some_field' => 'value'
         ];
@@ -136,8 +137,10 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function commonEntityIsNotFalselyIdentifiedAsIgnored()
+    public function partialMatchIsNotFalselyIdentifiedAsIgnored()
     {
+        // The rule is `'some_field: value other_field: a'` and the entity must match it entirely.
+
         $entity = [
             'some_field' => 'value'
         ];


### PR DESCRIPTION
Small follow-up after #1429.

The intention of two tests methods in `EntityInfoTest` was not clear, see https://github.com/versionpress/versionpress/pull/1429#pullrequestreview-231092304. I renamed the method names to hopefully be a bit clearer and added some comments.