### PR TITLE
Fix handling of values serialized multiple times

### DIFF
--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -57,7 +57,7 @@ class SerializedDataToIniConverter
      */
     public function fromIniLines($key, $lines)
     {
-        $value = substr($lines[$key], strlen(self::SERIALIZED_MARKER) + 1); // + space
+        $value = preg_replace('/' . preg_quote(self::SERIALIZED_MARKER) . ' /', '', $lines[$key], -1, $count);
         unset($lines[$key]);
 
         if (is_numeric($value)) {
@@ -69,7 +69,11 @@ class SerializedDataToIniConverter
             $relatedLines[substr($relatedKey, strlen($key))] = $lineValue;
         }
 
-        return $this->convertValueToSerializedString($value, $relatedLines);
+        $ret = $this->convertValueToSerializedString($value, $relatedLines);
+        for ($i = 1; $i < $count; $i++) {
+            $ret = serialize($ret);
+        }
+        return $ret;
     }
 
     /**

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -1566,6 +1566,43 @@ INI
     /**
      * @test
      */
+    public function doubleSerializedString()
+    {
+	$value = serialize(serialize('test'));
+	$this->assertSame('s:11:"s:4:"test";";', $value);
+        $data = ["Section" => ["data" => $value ] ];
+        $ini = StringUtils::ensureLf(<<<'INI'
+[Section]
+data = <<<serialized>>> <<<serialized>>> "test"
+
+INI
+        );
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+    }
+
+    /**
+     * @test
+     */
+    public function doubleSerializedArray()
+    {
+	$value = serialize(serialize(['test']));
+	$this->assertSame('s:21:"a:1:{i:0;s:4:"test";}";', $value);
+        $data = ["Section" => ["data" => $value ] ];
+        $ini = StringUtils::ensureLf(<<<'INI'
+[Section]
+data = <<<serialized>>> <<<serialized>>> <array>
+data[0] = "test"
+
+INI
+        );
+        $this->assertSame($ini, IniSerializer::serialize($data));
+        $this->assertSame($data, IniSerializer::deserialize($ini));
+    }
+
+    /**
+     * @test
+     */
     public function threeNestedSerializedValues()
     {
         $stdClass = new \stdClass();

--- a/plugins/versionpress/tests/Unit/IniSerializerTest.php
+++ b/plugins/versionpress/tests/Unit/IniSerializerTest.php
@@ -879,7 +879,7 @@ INI
 
         $this->assertSame($ini, IniSerializer::serialize($data));
         $this->assertSame($data, IniSerializer::deserialize($ini));
-        
+
     }
 
     /**
@@ -1568,15 +1568,16 @@ INI
      */
     public function doubleSerializedString()
     {
-	$value = serialize(serialize('test'));
-	$this->assertSame('s:11:"s:4:"test";";', $value);
-        $data = ["Section" => ["data" => $value ] ];
+	    $serializedValue = serialize(serialize('test'));
+
+        $data = ["Section" => ["data" => $serializedValue ] ];
         $ini = StringUtils::ensureLf(<<<'INI'
 [Section]
 data = <<<serialized>>> <<<serialized>>> "test"
 
 INI
         );
+
         $this->assertSame($ini, IniSerializer::serialize($data));
         $this->assertSame($data, IniSerializer::deserialize($ini));
     }
@@ -1586,9 +1587,9 @@ INI
      */
     public function doubleSerializedArray()
     {
-	$value = serialize(serialize(['test']));
-	$this->assertSame('s:21:"a:1:{i:0;s:4:"test";}";', $value);
-        $data = ["Section" => ["data" => $value ] ];
+	    $serializedValue = serialize(serialize(['test']));
+
+        $data = ["Section" => ["data" => $serializedValue ] ];
         $ini = StringUtils::ensureLf(<<<'INI'
 [Section]
 data = <<<serialized>>> <<<serialized>>> <array>
@@ -1596,6 +1597,7 @@ data[0] = "test"
 
 INI
         );
+
         $this->assertSame($ini, IniSerializer::serialize($data));
         $this->assertSame($data, IniSerializer::deserialize($ini));
     }


### PR DESCRIPTION
Resolves #1430 

Test cases have been described by @pavelevap in https://github.com/versionpress/versionpress/issues/1430#issuecomment-488575299, this PR adds them to tests and implements a fix.

Double serialized values like `serialize(serialize('some string'))` are now handled correctly.