### PR TITLE
 Update phpmyadmin/sql-parser to 4.3.1

### DIFF
--- a/plugins/versionpress/composer.json
+++ b/plugins/versionpress/composer.json
@@ -22,7 +22,7 @@
     "symfony/process": "^3.3",
     "michelf/php-markdown": "^1.7",
     "symfony/filesystem": "^3.3",
-    "phpmyadmin/sql-parser": "3.4",
+    "phpmyadmin/sql-parser": "^4",
     "tracy/tracy": "^2.4"
   },
   "require-dev": {

--- a/plugins/versionpress/composer.json
+++ b/plugins/versionpress/composer.json
@@ -29,7 +29,7 @@
     "phpunit/phpunit": "^5.7",
     "squizlabs/php_codesniffer": "^3.0",
     "fzaninotto/faker": "^1.6",
-    "mikey179/vfsStream": "^1.6",
+    "mikey179/vfsstream": "^1.6",
     "10up/wp_mock": "^0.1.1",
     "phpunit/phpunit-selenium": "^3.0",
     "icecave/semver": "^3.0"

--- a/plugins/versionpress/composer.json
+++ b/plugins/versionpress/composer.json
@@ -22,7 +22,7 @@
     "symfony/process": "^3.3",
     "michelf/php-markdown": "^1.7",
     "symfony/filesystem": "^3.3",
-    "phpmyadmin/sql-parser": "^4",
+    "phpmyadmin/sql-parser": "^4.3",
     "tracy/tracy": "^2.4"
   },
   "require-dev": {

--- a/plugins/versionpress/composer.lock
+++ b/plugins/versionpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "272518869b7fc998d665619af5ea7cf4",
+    "content-hash": "a48b6e6dabd7f05846c684a4dee3a392",
     "packages": [
         {
             "name": "michelf/php-markdown",

--- a/plugins/versionpress/composer.lock
+++ b/plugins/versionpress/composer.lock
@@ -775,12 +775,12 @@
             "version": "v1.6.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
                 "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
                 "shasum": ""
             },
@@ -1520,6 +1520,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-08T20:27:08+00:00"
         },
         {

--- a/plugins/versionpress/composer.lock
+++ b/plugins/versionpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d328bc2ba7d10eb5a7da42c0a6c0aa1d",
+    "content-hash": "272518869b7fc998d665619af5ea7cf4",
     "packages": [
         {
             "name": "michelf/php-markdown",
@@ -122,34 +122,47 @@
         },
         {
             "name": "phpmyadmin/sql-parser",
-            "version": "v3.4.0",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmyadmin/sql-parser.git",
-                "reference": "5c489d91f561cb0a63e0b63b29d6da71f626a137"
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/5c489d91f561cb0a63e0b63b29d6da71f626a137",
-                "reference": "5c489d91f561cb0a63e0b63b29d6da71f626a137",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/0eb16ef5e3acacbc792be336754e42d98791a33f",
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
             },
             "require-dev": {
-                "phpunit/php-code-coverage": "~2.0 || ~3.0",
-                "phpunit/phpunit": "~4.8 || ~5.1"
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5",
+                "sami/sami": "^4.0"
             },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query"
+            ],
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "SqlParser\\": "src"
+                    "PhpMyAdmin\\SqlParser\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -166,7 +179,7 @@
                 "parser",
                 "sql"
             ],
-            "time": "2016-02-23T08:51:30+00:00"
+            "time": "2019-01-05T13:46:38+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -216,6 +229,65 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2017-05-28T14:08:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/process",

--- a/plugins/versionpress/src/Database/SqlQueryParser.php
+++ b/plugins/versionpress/src/Database/SqlQueryParser.php
@@ -2,12 +2,12 @@
 
 namespace VersionPress\Database;
 
-use SqlParser\Parser;
-use SqlParser\Statement;
-use SqlParser\Statements\DeleteStatement;
-use SqlParser\Statements\InsertStatement;
-use SqlParser\Statements\ReplaceStatement;
-use SqlParser\Statements\UpdateStatement;
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statement;
+use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
+use PhpMyAdmin\SqlParser\Statements\InsertStatement;
+use PhpMyAdmin\SqlParser\Statements\ReplaceStatement;
+use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 
 class SqlQueryParser
 {


### PR DESCRIPTION
VersionPress was using 3.4.0; the latest version is 4.3.1.

Based on the changelog, this seems like a good idea: https://github.com/phpmyadmin/sql-parser/blob/v4.3.1/CHANGELOG.md