### PR TITLE
Use stripcslashes instead of stripslashes when handling values in sql

### DIFF
--- a/plugins/versionpress/src/Database/SqlQueryParser.php
+++ b/plugins/versionpress/src/Database/SqlQueryParser.php
@@ -204,7 +204,7 @@ class SqlQueryParser
         if ($sqlStatement instanceof UpdateStatement) {
             $dataSet = [];
             foreach ($sqlStatement->set as $set) {
-                $dataSet[str_replace('`', '', $set->column)] = stripslashes($set->value);
+                $dataSet[str_replace('`', '', $set->column)] = stripcslashes($set->value);
             };
             return $dataSet;
         } elseif ($sqlStatement instanceof InsertStatement) {
@@ -214,7 +214,7 @@ class SqlQueryParser
                 $data = [];
                 foreach ($sets->values as $i => $value) {
                     if (is_string($value)) {
-                        $data[$columns[$i]] = stripslashes($value);
+                        $data[$columns[$i]] = stripcslashes($value);
                     } else {
                         $data[$columns[$i]] = $value;
                     }

--- a/plugins/versionpress/tests/Unit/SqlQueryParserTest.php
+++ b/plugins/versionpress/tests/Unit/SqlQueryParserTest.php
@@ -193,6 +193,11 @@ class SqlQueryParserTest extends PHPUnit_Framework_TestCase
                 "INSERT INTO `wp_terms` (term_id, name) VALUES (10, 'term')",
                 [["term_id" => 10, "name" => "term"]],
                 ParsedQueryData::INSERT_QUERY
+            ],
+            [
+                "INSERT INTO `wp_terms` (term_id, name) VALUES (10, 'term line 1\\nterm line 2')",
+                [["term_id" => 10, "name" => "term line 1\nterm line 2"]],
+                ParsedQueryData::INSERT_QUERY
             ]
 
         ];
@@ -252,7 +257,14 @@ class SqlQueryParserTest extends PHPUnit_Framework_TestCase
                 "SELECT ID FROM `wp_posts` WHERE post_author = 5",
                 ["post_author" => 4],
                 $testIds
-            ]
+            ],
+            [
+                "UPDATE `wp_options` SET option_value='line 1\\nline 2'" .
+                "WHERE option_name LIKE '%_' AND option_value LIKE '%s'",
+                "SELECT option_name FROM `wp_options` WHERE option_name LIKE '%_' AND option_value LIKE '%s'",
+                ["option_value" => "'line 1\nline 2'"],
+                $testIds
+            ],
 
         ];
     }


### PR DESCRIPTION
Resolves #1436

For example, in query:
```
INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('lines', 'First row\nSecond row\nThird row', 'yes')
```
the extracted value should be:
```
First row
Second row
Third row
```
But, before this change, due to the use of `stripcslashes`, the value would be:
```
First rownSecond rownThird row
```
