### PR TITLE
Reorganize case sensitivity for matching entities and filtering commits

### DIFF
--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -226,16 +226,16 @@ class QueryLanguageUtils
             }
 
             if (substr($key, 0, 5) === 'x-vp-') {
-                $prefix = '';
+                $key = str_replace( 'x-vp-', 'X-VP-', $key );
             } else {
                 if (substr($key, 0, 3) === 'vp-') {
-                    $prefix = '\(X-\)\?';
+                    $key = '\(X-\)\?' . str_replace( 'vp-', 'VP-', $key );
                 } else {
-                    $prefix = '\(X-VP-\|VP-\)';
+                    $key = '\(X-VP-\|VP-\)' . $key;
                 }
             }
 
-            $query .= ' --grep="^' . $prefix . $key . ': \(' . implode('\|', $values) . '\)$"';
+            $query .= ' --grep="^' . $key . ': \(' . implode('\|', $values) . '\)$"';
         }
 
         return $query;

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -225,10 +225,10 @@ class QueryLanguageUtils
             }
 
             if (substr($key, 0, 5) === 'x-vp-') {
-                $key = str_replace( 'x-vp-', 'X-VP-', $key );
+                $key = str_replace('x-vp-', 'X-VP-', $key);
             } else {
                 if (substr($key, 0, 3) === 'vp-') {
-                    $key = '\(X-\)\?' . str_replace( 'vp-', 'VP-', $key );
+                    $key = '\(X-\)\?' . str_replace('vp-', 'VP-', $key);
                 } else {
                     $key = '\(X-VP-\|VP-\)' . $key;
                 }

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -21,10 +21,9 @@ class QueryLanguageUtils
      *  array = ['some_field' => ['value'], 'other_field' => ['other_value']]
      *
      * @param $queries
-     * @param $allowEmpty boolean Allow empty values
      * @return array
      */
-    public static function createRulesFromQueries($queries, $allowEmpty = false)
+    public static function createRulesFromQueries($queries)
     {
         $rules = [];
         foreach ($queries as $query) {
@@ -48,7 +47,7 @@ class QueryLanguageUtils
                 isset($match[4]) ? $match[4] : (
                 isset($match[3]) ? $match[3] : ''));
 
-                if ($value !== '' || $allowEmpty) {
+                if ($value !== '') {
                     if (!isset($ruleParts[$key])) {
                         $ruleParts[$key] = [];
                     }

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -36,7 +36,7 @@ class QueryLanguageUtils
 
             $ruleParts = [];
             foreach ($matches as $match) {
-                $key = empty($match[2]) ? 'text' : strtolower($match[2]);
+                $key = empty($match[2]) ? 'text' : $match[2];
 
                 /* value can be in 3rd, 4th or 5th index
                  *
@@ -44,9 +44,9 @@ class QueryLanguageUtils
                  * 4th index => value is in double quotes
                  * 5th index => value is without quotes
                  */
-                $value = strtolower(isset($match[5]) ? $match[5] : (
+                $value = isset($match[5]) ? $match[5] : (
                 isset($match[4]) ? $match[4] : (
-                isset($match[3]) ? $match[3] : '')));
+                isset($match[3]) ? $match[3] : ''));
 
                 if ($value !== '' || $allowEmpty) {
                     if (!isset($ruleParts[$key])) {
@@ -83,7 +83,7 @@ class QueryLanguageUtils
 
                 if ($isWildcard && preg_match(QueryLanguageUtils::tokensToRegex($valueTokens), $entity[$field])) {
                     return true;
-                } elseif (strtolower(strval($entity[$field])) === $value) {
+                } elseif (strval($entity[$field]) === $value) {
                     return true;
                 }
 
@@ -104,6 +104,7 @@ class QueryLanguageUtils
 
         $rule = [];
         foreach ($rawRule as $key => $array) {
+            $key = strtolower($key); // Lowercase all keys to ensure case insensitivity for converting rules
             $escapedKey = self::escapeGitLogArgument($key);
             $rule[$escapedKey] = ($key === 'date')
                 ? $rule[$escapedKey] = $array

--- a/plugins/versionpress/tests/Unit/EntityInfoTest.php
+++ b/plugins/versionpress/tests/Unit/EntityInfoTest.php
@@ -71,7 +71,7 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
                 'other_field' => ['a'],
             ],
             [
-                'capitalized_value_field' => ['value'], // the value is lowercased
+                'capitalized_value_field' => ['VALUE']
             ],
             [
                 'other_field' => ['value']
@@ -128,7 +128,7 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
         $entity = [
             'some_field' => 'b',
             'other_field' => 'a',
-            'capitalized_value_field' => 'VaLuE', // comparison must be case insensitive
+            'capitalized_value_field' => 'VALUE',
         ];
 
         $this->assertTrue($this->entityInfo->isIgnoredEntity($entity));

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -104,8 +104,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsCreatesCorrectRules($query, $expectedRules)
     {
         $rules = QueryLanguageUtils::createRulesFromQueries($query);
-        // Perform case insensitive match
-        $this->assertEquals($expectedRules, $rules, '', 0, 10, false, true);
+        $this->assertEquals($expectedRules, $rules);
     }
 
     public function queryAndRulesProvider()
@@ -139,8 +138,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsGeneratesCorrectGitLogQuery($rules, $expectedQuery)
     {
         $query = QueryLanguageUtils::createGitLogQueryFromRule($rules);
-        // Perform case insensitive match
-        $this->assertEquals($expectedQuery, $query, '', 0, 10, false, true);
+        $this->assertEquals($expectedQuery, $query);
     }
 
     public function rulesAndGitLogQueryProvider()
@@ -181,12 +179,12 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
                 '-i --all-match --grep="^VP-Action: \(entity\|.*\)/.*/\(.*vp.*\|vpid\)$"'
             ],
             [['text' => ['text1', 'Test text', '*']], '-i --all-match --grep="text1" --grep="Test text" --grep=".*"'],
-            [['X-vp-another-key' => ['Test value']], '-i --all-match --grep="^x-vp-another-key: \(Test value\)$"'],
-            [['vp-another-key' => ['Test value']], '-i --all-match --grep="^\(x-\)\?vp-another-key: \(Test value\)$"'],
-            [['another-key' => ['Test value']], '-i --all-match --grep="^\(x-vp-\|vp-\)another-key: \(Test value\)$"'],
+            [['X-vp-another-key' => ['Test value']], '-i --all-match --grep="^X-VP-another-key: \(Test value\)$"'],
+            [['vp-another-key' => ['Test value']], '-i --all-match --grep="^\(X-\)\?VP-another-key: \(Test value\)$"'],
+            [['another-key' => ['Test value']], '-i --all-match --grep="^\(X-VP-\|VP-\)another-key: \(Test value\)$"'],
             [
                 ['*-key' => ['^+?(){|$*\.[']],
-                '-i --all-match --grep="^\(x-vp-\|vp-\).*-key: \(^+?(){|\\\\\\$.*\\\\\\\\\.\[\)$"'
+                '-i --all-match --grep="^\(X-VP-\|VP-\).*-key: \(^+?(){|\\\\\\$.*\\\\\\\\\.\[\)$"'
             ]
         ];
     }

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -21,6 +21,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [['field: value'], ['field' => 'value']],
+            [['Field: VALUE'], ['Field' => 'VALUE']],
             [['field: value'], ['field' => 'value', 'other_field' => 'other_value']],
             [['field: 0'], ['field' => 0]],
             [['field: value other_field: other_value'], ['field' => 'value', 'other_field' => 'other_value']],
@@ -46,6 +47,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [['field: value'], ['field' => 'another_value']],
+            [['Field: VALUE'], ['field' => 'value']],
             [['field: value'], ['other_field' => 'value']],
             [['field: value'], ['field' => 0]],
             [['field: value other_field: other_value'], ['field' => 'value']],
@@ -71,6 +73,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [['field' => ['value']], '(`field` = "value")'],
+            [['Field' => ['VALUE']], '(`Field` = "VALUE")'],
             [
                 ['field' => ['value'], 'other_field' => ['other_value']],
                 '(`field` = "value" AND `other_field` = "other_value")'
@@ -178,7 +181,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
                 '-i --all-match --grep="^VP-Action: \(entity\|.*\)/.*/\(.*vp.*\|vpid\)$"'
             ],
             [['text' => ['text1', 'Test text', '*']], '-i --all-match --grep="text1" --grep="Test text" --grep=".*"'],
-            [['x-vp-another-key' => ['Test value']], '-i --all-match --grep="^x-vp-another-key: \(Test value\)$"'],
+            [['X-vp-another-key' => ['Test value']], '-i --all-match --grep="^x-vp-another-key: \(Test value\)$"'],
             [['vp-another-key' => ['Test value']], '-i --all-match --grep="^\(x-\)\?vp-another-key: \(Test value\)$"'],
             [['another-key' => ['Test value']], '-i --all-match --grep="^\(x-vp-\|vp-\)another-key: \(Test value\)$"'],
             [


### PR DESCRIPTION
Resolves #1439 

Case-insensitive comparison moved from `QueryLanguageUtils::createRulesFromQueries` and `QueryLanguageUtils::entityMatchesSomeRule` to `QueryLanguageUtils::createGitLogQueryFromRule`. This ensures that entities comparison will be case-sensitive and filtering commits case-insensitive without losing any information related to capitalized characters.
