### PR TITLE
Update CloneMergeTest and related to finish #1409

### DIFF
--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -27,8 +27,7 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
 
         self::$cloneSiteConfig = self::getCloneSiteConfig(self::$siteConfig);
 
-        // Currently, workflow tests only pass when they are run on a fresh WordPress install, see #1409. That's why
-        // we force a full setup here. In the future, just `$wpAutomation->ensureTestSiteIsReady` should be used.
+        // Currently, we use an empty site as a basic test.
         $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
         $wpAutomation->setUpSite();
         $wpAutomation->copyVersionPressFiles();

--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -26,12 +26,6 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
         self::$siteConfig = self::$testConfig->testSite;
 
         self::$cloneSiteConfig = self::getCloneSiteConfig(self::$siteConfig);
-
-        // Currently, we use an empty site as a basic test.
-        $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
-        $wpAutomation->setUpSite();
-        $wpAutomation->copyVersionPressFiles();
-        $wpAutomation->initializeVersionPress();
     }
 
     /**
@@ -39,6 +33,12 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
      */
     public function cloneLooksExactlySameAsOriginal()
     {
+        // Currently, we use an empty site as a basic test.
+        $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);
+        $wpAutomation->setUpSite();
+        $wpAutomation->copyVersionPressFiles();
+        $wpAutomation->initializeVersionPress();
+
         FileSystem::mkdir(self::$cloneSiteConfig->path);
 
         $wpAutomation = new WpAutomation(self::$siteConfig, self::$testConfig->wpCliVersion);

--- a/plugins/versionpress/tests/Workflow/CloneMergeTest.php
+++ b/plugins/versionpress/tests/Workflow/CloneMergeTest.php
@@ -199,15 +199,11 @@ class CloneMergeTest extends PHPUnit_Framework_TestCase
     private function assertCloneLooksExactlySameAsOriginal()
     {
         $origContent = $this->getTextContentAtUrl(self::$siteConfig->url);
-        // todo: remove replacing of line endings in #589
+
         $cloneContent = str_replace(
-            "\r\n",
-            "\n",
-            str_replace(
-                self::$cloneSiteConfig->name,
-                self::$siteConfig->name,
-                $this->getTextContentAtUrl(self::$cloneSiteConfig->url)
-            )
+            self::$cloneSiteConfig->name,
+            self::$siteConfig->name,
+            $this->getTextContentAtUrl(self::$cloneSiteConfig->url)
         );
 
         $this->assertEquals($origContent, $cloneContent);


### PR DESCRIPTION
Issue: #1409 
Follow-up to #1410 and #1421 

After we decided not to merge changes of #1421, see https://github.com/versionpress/versionpress/pull/1421#issuecomment-492123692, this is a follow-up PR to fix some of the comments and bring over some of the relevant commits from #1421, namely:

- Do not replace line endings on cloned site https://github.com/versionpress/versionpress/commit/099faf7d9787fccbd97f6ece10c7d635690b8a83 (originally https://github.com/versionpress/versionpress/pull/1421/commits/f07b6a610fc1faa145942563ed04daca7213e4fa).
- ~~TODO: should we bring over https://github.com/versionpress/versionpress/pull/1421/commits/9a84e45b7a57346e341ddbcd67c2e466a576f8ed as well?~~ Nope, see https://github.com/versionpress/versionpress/pull/1448#issuecomment-492163039.