### PR TITLE
Refactor case sensitivity in rule matching and commit searching, take 2

### DIFF
--- a/docs/content/en/developer/plugin-support.md
+++ b/docs/content/en/developer/plugin-support.md
@@ -389,12 +389,12 @@ entity:
 
 The values in the `frequently-written` array can either be strings which are then interpreted as queries, or objects with `query` and `interval` keys.
 
-- **Queries** use the same syntax as search / filtering in the UI, with some small differences like that the date range operator cannot be used but overall, the syntax is pretty intuitive. _TODO add link_
+- **Queries** identify entities via [this syntax](#query-syntax).
 - The **interval** is parsed by the `strtotime()` function and the default value is one hour.
 
 ### Ignoring entities
 
-Some entities should be ignored (not tracked at all) like transient options, environment-specific options, etc. This is an example from the `option` entity:
+Some entities should be ignored (not tracked at all) like transient options, environment-specific options, etc. [Queries](#query-syntax) are used again:
 
 ```yaml
   ignored-entities:
@@ -402,8 +402,6 @@ Some entities should be ignored (not tracked at all) like transient options, env
     - 'option_name: _site_transient_*'
     - 'option_name: siteurl'
 ```
-
-Again, queries are used. Wildcards are supported.
 
 ### Ignoring columns
 
@@ -568,3 +566,25 @@ TODO this will be auto-generated from code.
 
 - `vp_force_action`
     - `vp_force_action($scope, $action, $id = '', $tags = [], $files = [])`
+
+### Query syntax
+
+[Ignored](#ignoring-entities) and [frequently written](#frequently-written-entities) entities are identified using small queries that look like this:
+
+```yaml
+frequently-written:
+  - 'option_name: akismet_spam_count'
+ignored-entities:
+  - 'option_name: _transient_*'
+  - 'option_name: cron'
+  - ...
+```
+
+The syntax is generally shared with the [commit search](../feature-focus/searching-history.md):
+
+- Everything is case insensitive. `field: value` is equivalent to `field: VALUE` or `FiELd: vaLUE`.
+    - One caveat is that your database might be configured to use case sensitive comparisons, in which case you'll need to be precise. (WordPress uses the case insensitive `utf8_general_ci` collation by default.)
+- Wildcards are supported.
+- Multiple fields can be used, for example, `field1:value field2:value`.
+
+Unlike the full search, you can only target entity fields, not things like commit authors, date ranges, etc.

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -76,7 +76,7 @@ class QueryLanguageUtils
             return ArrayUtils::all($rule, function ($values, $field) use ($entity) {
                 $field = strtolower($field);
 
-                if (!isset($entity[strtolower($field)])) {
+                if (!isset($entity[$field])) {
                     return false;
                 }
 

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -70,10 +70,13 @@ class QueryLanguageUtils
      */
     public static function entityMatchesSomeRule($entity, $rules)
     {
+        $entity = array_change_key_case($entity, CASE_LOWER);
         return ArrayUtils::any($rules, function ($rule) use ($entity) {
             // check all parts of rule
             return ArrayUtils::all($rule, function ($values, $field) use ($entity) {
-                if (!isset($entity[$field])) {
+                $field = strtolower($field);
+
+                if (!isset($entity[strtolower($field)])) {
                     return false;
                 }
 

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -2,6 +2,32 @@
 
 namespace VersionPress\Utils;
 
+/**
+ * This class groups several functions around a small query language that is used in search
+ * and for ignored & frequently written entities in plugin definitions.
+ *
+ * Rules of the language:
+ *
+ * 1. Basic search with wildcard support: `just text` (all words), `"just text" (exact match)`, `w*ldcards`.
+ * 2. `operator:value` syntax for operators, with optional spaces after the colon.
+ * 3. Logical OR for repeated operators: `operator:value1 operator:value2`.
+ * 4. Logical AND for multiple operators: `operator1:value operator2:value`.
+ * 5. Everything is case insensitivity: `"search term" author: Joe` is equivalent to `"SEarCH TErm" Author: joe`.
+ *
+ * Notes on case insensitivity:
+ *
+ * - Rules are parsed as they are, maintaining their original letter casing.
+ * - When constructing Git search command, rules are passed as is but an `-i` flag is added.
+ * - When matching rules for for ignored and frequently written entities, case insensitive comparisons are done.
+ * - When constructing SQL restrictions, for example, `(field LIKE "value")`, values are passed without any
+ *   case conversion and it's up to the configuration of MySQL how it treats that. By default, WordPress
+ *   sets the case insensitive `utf8_general_ci` collation.
+ *
+ * When updating this code, also think about our public documentation related to this, currently in:
+ *
+ * - searching-history.md
+ * - plugin-support.md
+ */
 class QueryLanguageUtils
 {
 

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -14,6 +14,8 @@ namespace VersionPress\Utils;
  * 4. Logical AND for multiple operators: `operator1:value operator2:value`.
  * 5. Everything is case insensitivity: `"search term" author: Joe` is equivalent to `"SEarCH TErm" Author: joe`.
  *
+ * See examples in https://regex101.com/r/wT6zG3/6.
+ *
  * Notes on case insensitivity:
  *
  * - Rules are parsed as they are, maintaining their original letter casing.
@@ -34,7 +36,7 @@ class QueryLanguageUtils
     const VALUE_WILDCARD = 'VALUE_WILDCARD';
     const VALUE_STRING = 'VALUE_STRING';
 
-    // https://regex101.com/r/wT6zG3/4 (query language)
+    // https://regex101.com/r/wT6zG3/6 (query language)
     private static $queryRegex = "/(-)?(?:(\\S+):\\s*)?(?:'((?:[^'\\\\]|\\\\.)*)'|\"((?:[^\"\\\\]|\\\\.)*)\"|(\\S+))/";
 
     // https://regex101.com/r/pL2zA2/3 (support for * wildcard)
@@ -62,17 +64,19 @@ class QueryLanguageUtils
 
             $ruleParts = [];
             foreach ($matches as $match) {
+
+                // If a match is for an `operator:value` query, $match[2] is the operator
                 $key = empty($match[2]) ? 'text' : $match[2];
 
-                /* value can be in 3rd, 4th or 5th index
-                 *
-                 * 3rd index => value is in single quotes
-                 * 4th index => value is in double quotes
-                 * 5th index => value is without quotes
-                 */
-                $value = isset($match[5]) ? $match[5] : (
-                    isset($match[4]) ? $match[4] : (
-                    isset($match[3]) ? $match[3] : ''));
+                // Depending on how the value was quoted, it's available in a different index
+                $value =
+                    isset($match[5]) ? // unquoted value
+                    $match[5] :
+                    (isset($match[4]) ? // double quotes
+                    $match[4] :
+                    (isset($match[3]) ? // single quotes
+                    $match[3] :
+                    ''));
 
                 if ($value !== '' || $allowEmpty) {
                     if (!isset($ruleParts[$key])) {

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -227,10 +227,10 @@ class QueryLanguageUtils
                 continue;
             }
 
-            if (substr($key, 0, 5) === 'x-vp-') {
+            if (strtolower(substr($key, 0, 5)) === 'x-vp-') {
                 $prefix = '';
             } else {
-                if (substr($key, 0, 3) === 'vp-') {
+                if (strtolower(substr($key, 0, 3)) === 'vp-') {
                     $prefix = '\(X-\)\?';
                 } else {
                     $prefix = '\(X-VP-\|VP-\)';

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -3,29 +3,32 @@
 namespace VersionPress\Utils;
 
 /**
- * This class groups several functions around a small query language that is used in search
+ * This class contains several functions for handling a small query language that is used in search
  * and for ignored & frequently written entities in plugin definitions.
  *
  * Rules of the language:
  *
- * 1. Basic search with wildcard support: `just text` (all words), `"just text" (exact match)`, `w*ldcards`.
+ * 1. Basic search with wildcard support:
+ *     - `just text` – matches all words
+ *     - `"just text"` – exact match
+ *     - `w*ldcards`
  * 2. `operator:value` syntax for operators, with optional spaces after the colon.
- * 3. Logical OR for repeated operators: `operator:value1 operator:value2`.
+ * 3. Logical OR when the same operator is repeated: `operator:value1 operator:value2`.
  * 4. Logical AND for multiple operators: `operator1:value operator2:value`.
- * 5. Everything is case insensitivity: `"search term" author: Joe` is equivalent to `"SEarCH TErm" Author: joe`.
+ * 5. Everything is case insensitive: `"search term" author: Joe` is equivalent to `"SEarCH TErm" Author: JOE`.
  *
  * See examples in https://regex101.com/r/wT6zG3/6.
  *
- * Notes on case insensitivity:
+ * Notes on case (in)sensitivity:
  *
  * - Rules are parsed as they are, maintaining their original letter casing.
- * - When constructing Git search command, rules are passed as is but an `-i` flag is added.
- * - When matching rules for for ignored and frequently written entities, case insensitive comparisons are done.
+ * - When constructing Git search command, the `-i` flag is added to achieve case insensitivity (so it's up to Git).
+ * - When matching rules for ignored and frequently written entities, case insensitive comparisons are done.
  * - When constructing SQL restrictions, for example, `(field LIKE "value")`, values are passed without any
- *   case conversion and it's up to the configuration of MySQL how it treats that. By default, WordPress
+ *   case conversion and it's up to the configuration of MySQL how it treats it. By default, WordPress
  *   sets the case insensitive `utf8_general_ci` collation.
  *
- * When updating this code, also think about our public documentation related to this, currently in:
+ * DEVELOPER NOTE: When updating this code, also think about our public documentation related to this, currently in:
  *
  * - searching-history.md
  * - plugin-support.md

--- a/plugins/versionpress/src/Utils/QueryLanguageUtils.php
+++ b/plugins/versionpress/src/Utils/QueryLanguageUtils.php
@@ -36,7 +36,7 @@ class QueryLanguageUtils
 
             $ruleParts = [];
             foreach ($matches as $match) {
-                $key = empty($match[2]) ? 'text' : strtolower($match[2]);
+                $key = empty($match[2]) ? 'text' : $match[2];
 
                 /* value can be in 3rd, 4th or 5th index
                  *
@@ -44,9 +44,9 @@ class QueryLanguageUtils
                  * 4th index => value is in double quotes
                  * 5th index => value is without quotes
                  */
-                $value = strtolower(isset($match[5]) ? $match[5] : (
-                isset($match[4]) ? $match[4] : (
-                isset($match[3]) ? $match[3] : '')));
+                $value = isset($match[5]) ? $match[5] : (
+                    isset($match[4]) ? $match[4] : (
+                    isset($match[3]) ? $match[3] : ''));
 
                 if ($value !== '' || $allowEmpty) {
                     if (!isset($ruleParts[$key])) {
@@ -83,7 +83,7 @@ class QueryLanguageUtils
 
                 if ($isWildcard && preg_match(QueryLanguageUtils::tokensToRegex($valueTokens), $entity[$field])) {
                     return true;
-                } elseif (strtolower(strval($entity[$field])) === $value) {
+                } elseif (strtolower(strval($entity[$field])) === strtolower($value)) {
                     return true;
                 }
 

--- a/plugins/versionpress/tests/Unit/EntityInfoTest.php
+++ b/plugins/versionpress/tests/Unit/EntityInfoTest.php
@@ -71,7 +71,7 @@ class EntityInfoTest extends \PHPUnit_Framework_TestCase
                 'other_field' => ['a'],
             ],
             [
-                'capitalized_value_field' => ['value'], // the value is lowercased
+                'capitalized_value_field' => ['VALUE'],
             ],
             [
                 'other_field' => ['value']

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -20,19 +20,19 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function validQueryAndEntityProvider()
     {
         return [
-        	// basic rule matching
+            // basic rule matching
             [['field: value'], ['field' => 'value']],
             [['field: value'], ['field' => 'value', 'other_field' => 'other_value']],
             [['field: 0'], ['field' => 0]],
             [['field: value other_field: other_value'], ['field' => 'value', 'other_field' => 'other_value']],
 
-	        // wildcards
+            // wildcards
             [['field: val*'], ['field' => 'value']],
             [['field: *ue'], ['field' => 'value']],
             [['field: v*ue'], ['field' => 'value']],
             [['field: *al*'], ['field' => 'value']],
 
-	        // case insensitivity
+            // case insensitivity
             [['FIELD: value'], ['field' => 'value']],
             [['field: VALUE'], ['field' => 'value']],
             [['field: value'], ['FIELD' => 'value']],

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -185,12 +185,14 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
                 '-i --all-match --grep="^VP-Action: \(entity\|.*\)/.*/\(.*vp.*\|vpid\)$"'
             ],
             [['text' => ['text1', 'Test text', '*']], '-i --all-match --grep="text1" --grep="Test text" --grep=".*"'],
+
             [['x-vp-another-key' => ['Test value']], '-i --all-match --grep="^x-vp-another-key: \(Test value\)$"'],
-            [['vp-another-key' => ['Test value']], '-i --all-match --grep="^\(x-\)\?vp-another-key: \(Test value\)$"'],
-            [['another-key' => ['Test value']], '-i --all-match --grep="^\(x-vp-\|vp-\)another-key: \(Test value\)$"'],
+            [['X-VP-another-key' => ['Test value']], '-i --all-match --grep="^X-VP-another-key: \(Test value\)$"'],
+            [['vp-another-key' => ['Test value']], '-i --all-match --grep="^\(X-\)\?vp-another-key: \(Test value\)$"'],
+            [['another-key' => ['Test value']], '-i --all-match --grep="^\(X-VP-\|VP-\)another-key: \(Test value\)$"'],
             [
                 ['*-key' => ['^+?(){|$*\.[']],
-                '-i --all-match --grep="^\(x-vp-\|vp-\).*-key: \(^+?(){|\\\\\\$.*\\\\\\\\\.\[\)$"'
+                '-i --all-match --grep="^\(X-VP-\|VP-\).*-key: \(^+?(){|\\\\\\$.*\\\\\\\\\.\[\)$"'
             ]
         ];
     }

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -110,6 +110,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsCreatesCorrectRules($query, $expectedRules)
     {
         $rules = QueryLanguageUtils::createRulesFromQueries($query);
+        $this->assertEquals($expectedRules, $rules);
     }
 
     public function queryAndRulesProvider()
@@ -143,6 +144,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsGeneratesCorrectGitLogQuery($rules, $expectedQuery)
     {
         $query = QueryLanguageUtils::createGitLogQueryFromRule($rules);
+        $this->assertEquals($expectedQuery, $query);
     }
 
     public function rulesAndGitLogQueryProvider()

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -101,8 +101,6 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsCreatesCorrectRules($query, $expectedRules)
     {
         $rules = QueryLanguageUtils::createRulesFromQueries($query);
-        // Perform case insensitive match
-        $this->assertEquals($expectedRules, $rules, '', 0, 10, false, true);
     }
 
     public function queryAndRulesProvider()
@@ -136,8 +134,6 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function queryLanguageUtilsGeneratesCorrectGitLogQuery($rules, $expectedQuery)
     {
         $query = QueryLanguageUtils::createGitLogQueryFromRule($rules);
-        // Perform case insensitive match
-        $this->assertEquals($expectedQuery, $query, '', 0, 10, false, true);
     }
 
     public function rulesAndGitLogQueryProvider()

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -80,6 +80,7 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [['field' => ['value']], '(`field` = "value")'],
+            [['FIELD' => ['Value']], '(`FIELD` = "Value")'],
             [
                 ['field' => ['value'], 'other_field' => ['other_value']],
                 '(`field` = "value" AND `other_field` = "other_value")'

--- a/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
+++ b/plugins/versionpress/tests/Unit/QueryLanguageUtilsTest.php
@@ -20,15 +20,24 @@ class QueryLanguageUtilsTest extends \PHPUnit_Framework_TestCase
     public function validQueryAndEntityProvider()
     {
         return [
+        	// basic rule matching
             [['field: value'], ['field' => 'value']],
             [['field: value'], ['field' => 'value', 'other_field' => 'other_value']],
             [['field: 0'], ['field' => 0]],
             [['field: value other_field: other_value'], ['field' => 'value', 'other_field' => 'other_value']],
 
+	        // wildcards
             [['field: val*'], ['field' => 'value']],
             [['field: *ue'], ['field' => 'value']],
             [['field: v*ue'], ['field' => 'value']],
             [['field: *al*'], ['field' => 'value']],
+
+	        // case insensitivity
+            [['FIELD: value'], ['field' => 'value']],
+            [['field: VALUE'], ['field' => 'value']],
+            [['field: value'], ['FIELD' => 'value']],
+            [['field: value'], ['field' => 'VALUE']],
+            [['fIElD: VaLuE'], ['fieLD' => 'VAlue']],
         ];
     }
 


### PR DESCRIPTION
Issue: #1439 

This PR performs several refactoring around how we treat case (in)sensitivity in `QueryLanguageUtils` and related tests. It doesn't change the public behavior – both Git history searching and entity matching are still case **in**sensitive.

In fact, this PR improves the behavior a bit so that not only values are case insensitive but also fields. For example, `FIELD: value` now matches `['field' => 'value']` (or any other combination of letter casing).

> Note: This PR replaces #1444 where most of the refactorings started, however, it also changed the behavior of entity matching to be case sensitive which we decided against for now.

Details:

- Query parsing in `createRulesFromQueries` now maintains original letter casing. For example, `field: VALUE` will be parsed to `['field' => 'VALUE']`.
- Entity matching in `entityMatchesSomeRule` now uses case insensitive comparison explicitly.
- Git history searching uses the `-i` flag for case insensitive behavior. 
    - Some smaller changes in `createGitLogQueryFromRule` were also necessary, see 244daf4f3d2fd88dd051943b96fe140f963d121b.
- Fields are also treated case insensitively now, see a1c91e87ce1454254bd8aec0cf2e11c5bfaea968.
- Tests around Git search no longer use an ugly workaround with `assertEquals($expected, $actual, '', 0, 10, false, true)` which actually hid some small problems in the test code. Tests have been updated to match the reality.

Still TODO:

- [x] https://github.com/versionpress/versionpress/pull/1450#issuecomment-492853541
- [x] https://github.com/versionpress/versionpress/pull/1450#issuecomment-492933179
- ~~Cherry-pick removal of `allowEmpty` from #1444 c9b4e4a82a6d96ed92720c1dee5294ffcff76f84~~ I'll do this separately, this PR should be about case sensitivity only.
- [x] Update public documentation on the case insensitive behavior, how it also depends on DB collation, etc. 517b76eb9fe8986618daaeaffed5a89c5597a3fd
- [x] Update regex101 example and code docs. https://regex101.com/r/wT6zG3/6 & https://github.com/versionpress/versionpress/pull/1450/commits/09fa3bc9d66bf9230c1494a46ec84e7e761d174f.