### PR TITLE
change default icon

### DIFF
--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -719,7 +719,7 @@ function vp_admin_menu()
         'manage_options',
         'versionpress',
         'versionpress_page',
-        null,
+        'dashicons-backup,
         0.001234987
     );
 

--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -719,7 +719,7 @@ function vp_admin_menu()
         'manage_options',
         'versionpress',
         'versionpress_page',
-        'dashicons-backup,
+        'dashicons-backup',
         0.001234987
     );
 


### PR DESCRIPTION
I didn't like the default icon at the top for the admin menu. `dashicons-backup` (or any other preferred icon https://developer.wordpress.org/resource/dashicons/) might be better?