### PR TITLE
feat: added prefix option

### DIFF
--- a/docs/content/en/developer/plugin-support.md
+++ b/docs/content/en/developer/plugin-support.md
@@ -207,7 +207,7 @@ Again, this is prefix-less; `wp_` or another prefix will be added automatically.
 If you want to define a custom prefix for the entity you can define the `prefix` property. When defined Versionpress will prefix the table with it instead of the default one configured in `wp-config.php` (mostly `wp_`).
 
 ```yaml
-b2sUsers:
+b2sUser:
   table: users
   prefix: b2s_
   ...

--- a/docs/content/en/developer/plugin-support.md
+++ b/docs/content/en/developer/plugin-support.md
@@ -204,6 +204,15 @@ post:
 
 Again, this is prefix-less; `wp_` or another prefix will be added automatically.
 
+If you want to define a custom prefix for the entity you can define the `prefix` property. When defined Versionpress will prefix the table with it instead of the default one configured in `wp-config.php` (mostly `wp_`).
+
+```yaml
+post:
+  table: users
+  prefix: b2s_
+  ...
+```
+
 ### Identifying entities
 
 VersionPress needs to know how to identify entities. There are two approaches and they are represented by either using a `id` or `vpid` property in the schema:

--- a/docs/content/en/developer/plugin-support.md
+++ b/docs/content/en/developer/plugin-support.md
@@ -207,7 +207,7 @@ Again, this is prefix-less; `wp_` or another prefix will be added automatically.
 If you want to define a custom prefix for the entity you can define the `prefix` property. When defined Versionpress will prefix the table with it instead of the default one configured in `wp-config.php` (mostly `wp_`).
 
 ```yaml
-post:
+b2sUsers:
   table: users
   prefix: b2s_
   ...

--- a/plugins/versionpress/src/Database/DbSchemaInfo.php
+++ b/plugins/versionpress/src/Database/DbSchemaInfo.php
@@ -26,11 +26,11 @@ class DbSchemaInfo
     private $schema = [];
 
     /**
-     * Database tables prefix, e.g. "wp_"
+     * Database default tables prefix, e.g. "wp_"
      *
      * @var string
      */
-    private $prefix;
+    private $defaultPrefix;
 
     /**
      * @var array entityName => EntityInfo object. Lazily constructed, see getEntityInfo().
@@ -48,7 +48,7 @@ class DbSchemaInfo
     public function __construct($schemaFiles, $prefix, $dbVersion)
     {
         $this->dbVersion = $dbVersion;
-        $this->prefix = $prefix;
+        $this->defaultPrefix = $prefix;
 
         $this->refreshDbSchema($schemaFiles);
     }
@@ -122,7 +122,7 @@ class DbSchemaInfo
         if (isset($tablePrefix)) {
             return $tablePrefix . $this->getTableName($entityName);
         } else {
-            return $this->prefix . $this->getTableName($entityName);
+            return $this->defaultPrefix . $this->getTableName($entityName);
         }
     }
 
@@ -280,6 +280,6 @@ class DbSchemaInfo
 
     public function trimPrefix($tableName)
     {
-        return substr($tableName, strlen($this->prefix));
+        return substr($tableName, strlen($this->defaultPrefix));
     }
 }

--- a/plugins/versionpress/src/Database/DbSchemaInfo.php
+++ b/plugins/versionpress/src/Database/DbSchemaInfo.php
@@ -110,13 +110,20 @@ class DbSchemaInfo
 
     /**
      * For something like "post", returns "wp_posts"
+     * This will respect the custom prefix from the entity.
      *
      * @param $entityName
      * @return string
      */
     public function getPrefixedTableName($entityName)
     {
-        return $this->prefix . $this->getTableName($entityName);
+        $tablePrefix = $this->getEntityInfo($entityName)->tablePrefix;
+
+        if (isset($tablePrefix)) {
+            return $tablePrefix . $this->getTableName($entityName);
+        } else {
+            return $this->prefix . $this->getTableName($entityName);
+        }
     }
 
     /**

--- a/plugins/versionpress/src/Database/EntityInfo.php
+++ b/plugins/versionpress/src/Database/EntityInfo.php
@@ -29,6 +29,13 @@ class EntityInfo
     public $tableName;
 
     /**
+     * Custom defined prefix for the table. By default the default prefix is prepended to the table name.
+     *
+     * @var string
+     */
+    public $tablePrefix;
+
+    /**
      * Name of a column that uniquely identifies the entity within a db table. This is most
      * commonly an auto-increment primary key but not always - e.g., options use the 'option_name'
      * which is not a primary key in that table but is a local id as far as VersionPress is concerned.
@@ -167,6 +174,10 @@ class EntityInfo
             $this->tableName = $schemaInfo['table'];
         } else {
             $this->tableName = $this->entityName;
+        }
+
+        if (isset($schemaInfo['prefix'])) {
+            $this->tablePrefix = $schemaInfo['prefix'];
         }
 
         // The schema defines either 'id' or 'vpid', see schema-readme.md. This has this meaning:


### PR DESCRIPTION
@borekb as discussed [in Gitter](https://gitter.im/versionpress/versionpress?at=5d249fafd0e06b6675746d03).

To make third party plugins that use a custom database prefix (different than `$wpdb->prefix`) compatible with VersionPress, you can now define a property `prefix` in `schema.yml` in order to prefix the table name of the entity with a custom one.