### PR TITLE
Always allow automatic updates

### DIFF
--- a/plugins/versionpress/setup-hooks.php
+++ b/plugins/versionpress/setup-hooks.php
@@ -78,8 +78,7 @@ if (VersionPress::isActive()) {
 //----------------------------------
 
 add_filter('automatic_updates_is_vcs_checkout', function () {
-    $forceUpdate = UninstallationUtil::uninstallationShouldRemoveGitRepo(); // first commit was created by VersionPress
-    return !$forceUpdate; // 'false' forces the update
+    return !VersionPress::isActive(); // 'false' allows the update
 });
 
 function vp_register_hooks()


### PR DESCRIPTION
`automatic_updates_is_vcs_checkout` should return false as long as VersionPress is active allowing automatic updates

Whether the first commit in the git repo is a VP activation commit or not is irrelevant.

@borekb @pavelevap What do you think?
