### PR TITLE
Removed double slash in admin URL

### DIFF
--- a/frontend/src/components/service-panel/panel/Support.tsx
+++ b/frontend/src/components/service-panel/panel/Support.tsx
@@ -15,7 +15,7 @@ const Support: React.StatelessComponent<{}> = () => (
         Please visit our <a href='https://github.com/versionpress/support'>support&nbsp;repository</a>.
       </li>
       <li>
-        <a href={`${config.api.adminUrl}/admin.php?page=versionpress/admin/system-info.php`}>
+        <a href={`${config.api.adminUrl}admin.php?page=versionpress/admin/system-info.php`}>
           System information
         </a> page.
       </li>


### PR DESCRIPTION
Looks like there is two forward slashes. It's not breaking anything but it shouldn't be there.

Resolves #

![Screen Shot 2019-12-22 at 10 07 18 AM](https://user-images.githubusercontent.com/1872327/71323616-1e02f180-24a3-11ea-9e40-29e5b295188a.png)