### PR TITLE
Fix typos

### DIFF
--- a/docs/content/en/feature-focus/custom-project-structure.md
+++ b/docs/content/en/feature-focus/custom-project-structure.md
@@ -3,7 +3,7 @@
 Some advanced users like having WordPress in its own directory or move plugins, themes or uploads in another directory. VersionPress supports some scenarios. Just remember that all files related to the site have to be under the project root ([`VP_PROJECT_ROOT`](../getting-started/configuration.md#vp_project_root)).
 
 !!! warning
-    You need to adjust your project structure _before_ fully initalizing VersionPress. The recommended procedure is:
+    You need to adjust your project structure _before_ fully initializing VersionPress. The recommended procedure is:
 
      * Customize your WordPress site structure.
      * Install and active VersionPress, the plugin – do _not_ go through the full initialization yet.

--- a/docs/content/en/release-notes/4.0-beta2.md
+++ b/docs/content/en/release-notes/4.0-beta2.md
@@ -43,7 +43,7 @@ On a related note, **@pavelevap** is joining the project as an official maintain
 [#1423](https://github.com/versionpress/versionpress/pull/1423) Update docs on development process ([#1417](https://github.com/versionpress/versionpress/issues/1417))<br>
 [#1422](https://github.com/versionpress/versionpress/pull/1422) Fix `run-tests.ts`: return non-zero exit code when tests fail<br>
 [#1415](https://github.com/versionpress/versionpress/pull/1415) Have Travis run tests ([#1259](https://github.com/versionpress/versionpress/issues/1259))<br>
-[#1418](https://github.com/versionpress/versionpress/pull/1418) Update frontend dependecies<br>
+[#1418](https://github.com/versionpress/versionpress/pull/1418) Update frontend dependencies<br>
 [#1414](https://github.com/versionpress/versionpress/pull/1414) Fix markdownlint violation in `docs/content/en/troubleshooting/iis.md`<br>
 [#1411](https://github.com/versionpress/versionpress/pull/1411) Small updates of exploring the test WP site after tests have run<br>
 [#1410](https://github.com/versionpress/versionpress/pull/1410) Fresh site setup before CloneMergeTest (workaround) ([#1409](https://github.com/versionpress/versionpress/issues/1409))<br>
@@ -79,7 +79,7 @@ On a related note, **@pavelevap** is joining the project as an official maintain
 [#1340](https://github.com/versionpress/versionpress/pull/1340) Document `VP_WP_CLI_BINARY` setting<br>
 [#1341](https://github.com/versionpress/versionpress/pull/1341) Update intro section on Docker<br>
 [#1338](https://github.com/versionpress/versionpress/pull/1338) Fix frontend package vulnerabilities ([#1335](https://github.com/versionpress/versionpress/issues/1335))<br>
-[#1337](https://github.com/versionpress/versionpress/pull/1337) Update frontend dependecies ([#1335](https://github.com/versionpress/versionpress/issues/1335))<br>
+[#1337](https://github.com/versionpress/versionpress/pull/1337) Update frontend dependencies ([#1335](https://github.com/versionpress/versionpress/issues/1335))<br>
 [#1334](https://github.com/versionpress/versionpress/pull/1334) Switch to MkDocs for documentation ([#1332](https://github.com/versionpress/versionpress/issues/1332))<br>
 [#1329](https://github.com/versionpress/versionpress/pull/1329) Dev setup updates – spring 2018<br>
 [#1318](https://github.com/versionpress/versionpress/pull/1318) Fix typo in activation message<br>

--- a/plugins/versionpress/src/ChangeInfos/EntityChangeInfo.php
+++ b/plugins/versionpress/src/ChangeInfos/EntityChangeInfo.php
@@ -7,7 +7,7 @@ use VersionPress\Database\EntityInfo;
 
 /**
  * Base class for entity change infos like PostChangeInfo, CommentChangeInfo etc.
- * An entity is a database-tracked object that usually has a VPID (but not alwasy, see e.g. options).
+ * An entity is a database-tracked object that usually has a VPID (but not always, see e.g. options).
  *
  * Derived ChangeInfos have these things in common:
  *

--- a/plugins/versionpress/src/Cli/vp.php
+++ b/plugins/versionpress/src/Cli/vp.php
@@ -673,7 +673,7 @@ class VPCommand extends WP_CLI_Command
         if (is_dir($remoteUrl)) {
             $this->runVPInternalCommand('commit-frequently-written-entities', [], $remoteUrl);
         } else {
-            // We currently do not support commiting frequently written entities for repositories on a different server
+            // We currently do not support committing frequently written entities for repositories on a different server
         }
 
         $this->switchMaintenance('on');
@@ -1100,7 +1100,7 @@ class VPCommand extends WP_CLI_Command
             $this->switchMaintenance('off');
         } else {
             WP_CLI::error(join("\n", [
-                'Update failed. Unfortunatelly, you have to manually update VersionPress.',
+                'Update failed. Unfortunately, you have to manually update VersionPress.',
                 ' 1. Delete wp-content/versionpress.',
                 ' 2. Extract the ZIP to wp-content/versionpress.',
                 ' 3. Run \'wp plugin activate versionpress\' and \'wp vp activate\'.',

--- a/plugins/versionpress/src/Git/ChangeInfoPreprocessors/TermTaxonomyPreprocessor.php
+++ b/plugins/versionpress/src/Git/ChangeInfoPreprocessors/TermTaxonomyPreprocessor.php
@@ -18,7 +18,7 @@ class TermTaxonomyPreprocessor implements ChangeInfoPreprocessor
     }
 
     /**
-     * Reads taxonomy from `term_taxonomy` action and assings it to `term`.
+     * Reads taxonomy from `term_taxonomy` action and assigns it to `term`.
      *
      * @param ChangeInfo[] $changeInfoList
      * @return ChangeInfo[][]

--- a/plugins/versionpress/src/Git/GitRepository.php
+++ b/plugins/versionpress/src/Git/GitRepository.php
@@ -79,7 +79,7 @@ class GitRepository
         $tempCommitMessagePath = $this->tempDirectory . '/' . $tempCommitMessageFilename;
         file_put_contents($tempCommitMessagePath, $commitMessage);
 
-        // Unfortunatelly, `git commit --author=...` is not enough.
+        // Unfortunately, `git commit --author=...` is not enough.
         // It doesn't work with empty both local and global config.
         $localConfigUserName = $this->runShellCommandWithStandardOutput('git config --local user.name');
         $localConfigUserEmail = $this->runShellCommandWithStandardOutput('git config --local user.email');

--- a/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
+++ b/plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php
@@ -19,7 +19,7 @@ class SerializedDataToIniConverter
     private $value;
 
     /**
-     * Converts PHP-serialized string to mutiple INI lines.
+     * Converts PHP-serialized string to multiple INI lines.
      *
      * For example string 'a:1:{i:0;s:3:"foo";}' with key 'data' is converted to
      * [

--- a/plugins/versionpress/src/Utils/RequirementsChecker.php
+++ b/plugins/versionpress/src/Utils/RequirementsChecker.php
@@ -45,7 +45,7 @@ class RequirementsChecker
      * RequirementsChecker constructor.
      * @param Database $database
      * @param DbSchemaInfo $schema
-     * @param string $checkScope determines if all VersionPress requirements need to be fullfilled or just some of them.
+     * @param string $checkScope determines if all VersionPress requirements need to be fulfilled or just some of them.
      * Possible values are RequirementsChecker::SITE or RequirementsChecker::ENVIRONMENT
      * Default value is RequirementsChecker::SITE which means that all requirements need to be matched.
      * RequirementsChecker::ENVIRONMENT checks only requirements related to "runtime" environment.

--- a/plugins/versionpress/tests/End2End/Utils/SeleniumWorker.php
+++ b/plugins/versionpress/tests/End2End/Utils/SeleniumWorker.php
@@ -188,7 +188,7 @@ class SeleniumWorker implements ITestWorker
     }
 
     /**
-     * Small wrapper aroung built-in execute() method
+     * Small wrapper around built-in execute() method
      *
      * @param string $code JavaScript code
      * @return string JS result, if any

--- a/plugins/versionpress/tests/Selenium/SeleniumTestCase.php
+++ b/plugins/versionpress/tests/Selenium/SeleniumTestCase.php
@@ -108,7 +108,7 @@ abstract class SeleniumTestCase extends PHPUnit_Extensions_Selenium2TestCase
     }
 
     /**
-     * Small wrapper aroung built-in execute() method
+     * Small wrapper around built-in execute() method
      *
      * @param string $code JavaScript code
      * @return string JS result, if any

--- a/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
+++ b/plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php
@@ -102,7 +102,7 @@ class SynchronizerTestCase extends \PHPUnit_Framework_TestCase
     public static function tearDownAfterClass()
     {
         $process = new Process(
-            "git add -A && git commit -m " . ProcessUtils::escapeshellarg("Commited changes made by " . get_called_class()),
+            "git add -A && git commit -m " . ProcessUtils::escapeshellarg("Committed changes made by " . get_called_class()),
             self::$testConfig->testSite->path
         );
         $process->run();

--- a/plugins/versionpress/tests/Unit/ActionsInfoProviderTest.php
+++ b/plugins/versionpress/tests/Unit/ActionsInfoProviderTest.php
@@ -184,7 +184,7 @@ class ActionsInfoProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Creates a virtual file containg YAML created from $scopesDefinition and returns its path.
+     * Creates a virtual file containing YAML created from $scopesDefinition and returns its path.
      *
      * @param array $scopesDefinition
      * @return string

--- a/plugins/versionpress/tests/Unit/DbSchemaInfoTest.php
+++ b/plugins/versionpress/tests/Unit/DbSchemaInfoTest.php
@@ -152,7 +152,7 @@ class DbSchemaInfoTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * Creates a virtual file containg YAML created from $scopesDefinition and returns its path.
+     * Creates a virtual file containing YAML created from $scopesDefinition and returns its path.
      *
      * @param array $scopesDefinition
      * @return string

--- a/plugins/versionpress/tests/Unit/IniSerializer_IssueWP284Test.php
+++ b/plugins/versionpress/tests/Unit/IniSerializer_IssueWP284Test.php
@@ -20,7 +20,7 @@ class IniSerializer_IssueWP284Test extends PHPUnit_Framework_TestCase
     public function justSerializedValue()
     {
 
-        // All HTML replaced wtih empty string
+        // All HTML replaced with empty string
 
         $data = [
             "avia_options_enfold" => [
@@ -333,7 +333,7 @@ INI
 
 						<div class='live-main_color border avia_half'>
 							<h3 class='webfont_google_webfont main_h3'>Main Content heading</h3>
-								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be choosen below. <br/>
+								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be chosen below. <br/>
 									<a class='a_link' href='#'>A link</a>
 									<a class='an_activelink' href='#'>A hovered link</a>
 								</p>
@@ -441,7 +441,7 @@ option_value = "<style type='text/css'>
 
 						<div class='live-main_color border avia_half'>
 							<h3 class='webfont_google_webfont main_h3'>Main Content heading</h3>
-								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be choosen below. <br/>
+								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be chosen below. <br/>
 									<a class='a_link' href='#'>A link</a>
 									<a class='an_activelink' href='#'>A hovered link</a>
 								</p>
@@ -927,7 +927,7 @@ a:1:{s:4:"avia";a:174:{s:21:"default_layout_target";s:5431:"
 
 						<div class='live-main_color border avia_half'>
 							<h3 class='webfont_google_webfont main_h3'>Main Content heading</h3>
-								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be choosen below. <br/>
+								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be chosen below. <br/>
 									<a class='a_link' href='#'>A link</a>
 									<a class='an_activelink' href='#'>A hovered link</a>
 								</p>
@@ -1218,7 +1218,7 @@ option_value = "a:1:{s:4:\"avia\";a:174:{s:21:\"default_layout_target\";s:5431:\
 
 						<div class='live-main_color border avia_half'>
 							<h3 class='webfont_google_webfont main_h3'>Main Content heading</h3>
-								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be choosen below. <br/>
+								<p class='content_p'>This is default content with a default heading. Font color, headings and link colors can be chosen below. <br/>
 									<a class='a_link' href='#'>A link</a>
 									<a class='an_activelink' href='#'>A hovered link</a>
 								</p>

--- a/plugins/versionpress/tests/Utils/DBAsserter.php
+++ b/plugins/versionpress/tests/Utils/DBAsserter.php
@@ -351,7 +351,7 @@ class DBAsserter
 
     /**
      * Defines global constants, container and wpdb dynamic mapping of value references.
-     * It's not pretty, but makes the mapping functions very flexible (they can have various dependecies).
+     * It's not pretty, but makes the mapping functions very flexible (they can have various dependencies).
      */
     private static function defineGlobalVariables()
     {


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `docs/content/en/feature-focus/custom-project-structure.md`
- 2 typos in `docs/content/en/release-notes/4.0-beta2.md`
- 1 typo in `plugins/versionpress/src/ChangeInfos/EntityChangeInfo.php`
- 2 typos in `plugins/versionpress/src/Cli/vp.php`
- 1 typo in `plugins/versionpress/src/Git/ChangeInfoPreprocessors/TermTaxonomyPreprocessor.php`
- 1 typo in `plugins/versionpress/src/Git/GitRepository.php`
- 1 typo in `plugins/versionpress/src/Storages/Serialization/SerializedDataToIniConverter.php`
- 1 typo in `plugins/versionpress/src/Utils/RequirementsChecker.php`
- 1 typo in `plugins/versionpress/tests/End2End/Utils/SeleniumWorker.php`
- 1 typo in `plugins/versionpress/tests/Selenium/SeleniumTestCase.php`
- 1 typo in `plugins/versionpress/tests/SynchronizerTests/SynchronizerTestCase.php`
- 1 typo in `plugins/versionpress/tests/Unit/ActionsInfoProviderTest.php`
- 1 typo in `plugins/versionpress/tests/Unit/DbSchemaInfoTest.php`
- 5 typos in `plugins/versionpress/tests/Unit/IniSerializer_IssueWP284Test.php`
- 1 typo in `plugins/versionpress/tests/Utils/DBAsserter.php`



Ciao! :robot: