### PR TITLE
fix broken link

### DIFF
--- a/docs/content/en/sync/index.md
+++ b/docs/content/en/sync/index.md
@@ -2,7 +2,7 @@
 
 This sections discusses how VersionPress handles multiple site instances like *staging* and *live*, cloning and merging between them, etc.
 
-See also the [blog post on staging](https://blog.versionpress.net/2015/09/versionpress-2-0-staging/).
+See also the [blog post on staging](https://versionpress.com/blog/2015/09/versionpress-2-0-staging/).
 
 !!! note "Available since VersionPress 2.0"
     The functionality described in this section is available since the [2.0 release](../release-notes/2.0.md).


### PR DESCRIPTION
https://blog.versionpress.net/2015/09/versionpress-2-0-staging/ 
this url doesnt exist
found at https://versionpress.com/blog/2015/09/versionpress-2-0-staging/
