### PR TITLE
Ensure is_string before trying unserialize

### DIFF
--- a/plugins/versionpress/src/Utils/StringUtils.php
+++ b/plugins/versionpress/src/Utils/StringUtils.php
@@ -144,6 +144,9 @@ class StringUtils
      */
     public static function isSerializedValue($value)
     {
+        if (!is_string($value)) {
+            return false;
+        }
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
         $test = @unserialize(($value)); // it throws an error and returns false if $value is not a serialized object
         return $test !== false || $value === 'b:0;';


### PR DESCRIPTION
PHP 8 will throw a fatal error if a non-string (ex, an array) is passed to `unserialize`. So make sure the value is a string before calling `unserialize`.

Example stack trace:
```
PHP Fatal error:  Uncaught TypeError: unserialize(): Argument #1 ($data) must be of type string, array given in /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php:148
Stack trace:
#0 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php(148): unserialize()
#1 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php(72): VersionPress\Utils\StringUtils::isSerializedValue()
#2 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php(53): VersionPress\Utils\AbsoluteUrlReplacer->replacePlaceholders()
#3 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(234): VersionPress\Utils\AbsoluteUrlReplacer->restore()
#4 [internal function]: VersionPress\Synchronizers\Synchronizer->VersionPress\Synchronizers\{closure}()
#5 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(233): array_map()
#6 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(203): VersionPress\Synchronizers\Synchronizer->loadEntitiesFromStorage()
#7 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(137): VersionPress\Synchronizers\Synchronizer->maybeInit()
#8 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/SynchronizationProcess.php(66): VersionPress\Synchronizers\Synchronizer->synchronize()
#9 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/SynchronizationProcess.php(57): VersionPress\Synchronizers\SynchronizationProcess->runSynchronizationTasks()
#10 /var/www/candrews/wp-content/plugins/versionpress/src/Cli/vp.php(789): VersionPress\Synchronizers\SynchronizationProcess->synchronizeAll()
#11 [internal function]: VersionPress\Cli\VPCommand->applyChanges()
#12 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(98): call_user_func()
#13 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}()
#14 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(451): call_user_func()
#15 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(371): WP_CLI\Dispatcher\Subcommand->invoke()
#16 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(394): WP_CLI\Runner->run_command()
#17 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1160): WP_CLI\Runner->run_command_and_exit()
#18 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#19 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process()
#20 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#21 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('...')
#22 /usr/local/bin/wp(4): include('...')
#23 {main}
  thrown in /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php on line 148
Fatal error: Uncaught TypeError: unserialize(): Argument #1 ($data) must be of type string, array given in /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php:148
Stack trace:
#0 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php(148): unserialize()
#1 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php(72): VersionPress\Utils\StringUtils::isSerializedValue()
#2 /var/www/candrews/wp-content/plugins/versionpress/src/Utils/AbsoluteUrlReplacer.php(53): VersionPress\Utils\AbsoluteUrlReplacer->replacePlaceholders()
#3 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(234): VersionPress\Utils\AbsoluteUrlReplacer->restore()
#4 [internal function]: VersionPress\Synchronizers\Synchronizer->VersionPress\Synchronizers\{closure}()
#5 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(233): array_map()
#6 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(203): VersionPress\Synchronizers\Synchronizer->loadEntitiesFromStorage()
#7 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/Synchronizer.php(137): VersionPress\Synchronizers\Synchronizer->maybeInit()
#8 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/SynchronizationProcess.php(66): VersionPress\Synchronizers\Synchronizer->synchronize()
#9 /var/www/candrews/wp-content/plugins/versionpress/src/Synchronizers/SynchronizationProcess.php(57): VersionPress\Synchronizers\SynchronizationProcess->runSynchronizationTasks()
#10 /var/www/candrews/wp-content/plugins/versionpress/src/Cli/vp.php(789): VersionPress\Synchronizers\SynchronizationProcess->synchronizeAll()
#11 [internal function]: VersionPress\Cli\VPCommand->applyChanges()
#12 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(98): call_user_func()
#13 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}()
#14 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(451): call_user_func()
#15 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(371): WP_CLI\Dispatcher\Subcommand->invoke()
#16 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(394): WP_CLI\Runner->run_command()
#17 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1160): WP_CLI\Runner->run_command_and_exit()
#18 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#19 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process()
#20 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#21 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('...')
#22 /usr/local/bin/wp(4): include('...')
#23 {main}
  thrown in /var/www/candrews/wp-content/plugins/versionpress/src/Utils/StringUtils.php on line 148
Error: There has been a critical error on this website.Learn more about debugging in WordPress. There has been a critical error on this website.
```